### PR TITLE
chore(csrf): CSRF 토큰 컨트롤러를 main 소스로 이동하고 test 환경에서만 활성화

### DIFF
--- a/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
+++ b/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
@@ -1,5 +1,6 @@
-package com.test.basic.posts;
+package com.test.basic.auth.csrf;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,9 +8,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Profile("test") // test 환경에서만 활성화됨
 @RequestMapping("/csrf")
-public class CsrfTokenProvider {
+public class CsrfTokenController {
 
+    // RestTemplate이나 테스트 환경에선 CSRF 자동 관리가 안돼서 테스트용으로 만든 API
     @GetMapping
     public ResponseEntity<?> csrf(CsrfToken csrfToken) {
         // CSRF 토큰을 응답 헤더에 포함하여 반환

--- a/src/test/java/com/test/basic/users/UserControllerTest.java
+++ b/src/test/java/com/test/basic/users/UserControllerTest.java
@@ -7,7 +7,7 @@ import com.test.basic.auth.jwt.JwtTokenProvider;
 import com.test.basic.auth.security.CustomUserDetailsService;
 import com.test.basic.auth.security.config.SecurityConfig;
 import com.test.basic.common.utils.RSAUtil;
-import com.test.basic.posts.CsrfTokenProvider;
+import com.test.basic.auth.csrf.CsrfTokenController;
 import jakarta.servlet.http.Cookie;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // == 보안이 적용된 컨트롤러 단위 테스트 =====================
 // Controller만 테스트하기 위해 사용
 // 서비스 로직 없이 컨트롤러의 HTTP 요청/응답만 테스트하려는 목적으로 사용
-@WebMvcTest({ UserController.class, AuthController.class, CsrfTokenProvider.class })
+@WebMvcTest({ UserController.class, AuthController.class, CsrfTokenController.class })
 // JUnit 5 (@Test) 환경에서 Mockito(목킹 프레임워크)를 사용. => 목킹(Mock) 기능을 확장
 // Spring 컨텍스트를 로드하지 않고 가벼운 단위 테스트 가능
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION

- @Profile("test") 애노테이션 추가
- 운영 환경에선 노출되지 않도록 설정
- 테스트 통합 시에만 사용됨
