### PR TITLE
###CustomUserDetails 적용에 따른 인증 로직 및 테스트 리팩토링

### DIFF
--- a/src/main/java/com/test/basic/HomeController.java
+++ b/src/main/java/com/test/basic/HomeController.java
@@ -41,11 +41,11 @@ public class HomeController {
 	@GetMapping(value = { "/", "/home" })
 	public String mainPage(Model model, Authentication authentication, @AuthenticationPrincipal Jwt jwt) {
 		if (authentication != null) {
-			logger.info(authentication.getName());
+			logger.info(authentication.getName());	// == jwt.getClaim("sub") == userId
 		}
 
 		if (jwt != null) {
-			model.addAttribute("username", jwt.getClaim("sub"));
+			model.addAttribute("username", jwt.getClaimAsString("username"));
 			// JWT 만료 시간 추출 및 전달 (한국 시간)
 			Instant expirationTime = jwt.getExpiresAt();
 			LocalDateTime expirationTimeKST = LocalDateTime.ofInstant(expirationTime, ZoneId.of("Asia/Seoul"));

--- a/src/main/java/com/test/basic/auth/AuthController.java
+++ b/src/main/java/com/test/basic/auth/AuthController.java
@@ -2,7 +2,6 @@ package com.test.basic.auth;
 
 import com.test.basic.auth.jwt.JwtTokenProvider;
 import com.test.basic.users.UserEntity;
-import com.test.basic.users.UserRepository;
 import com.test.basic.users.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,10 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +27,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
-import java.util.Optional;
 
 @Tag(name = "Auth API", description = "권한 관리 API")
 @RequestMapping("/auth")
@@ -67,12 +63,13 @@ public class AuthController {
     @SecurityRequirement(name = "BasicAuth")  // 🔥 Swagger에서 Basic Auth로 인증 가능
     public ResponseEntity login(Authentication authentication, HttpServletResponse response) throws Exception {
         // 1. Basic Authentication 정보는 이미 authentication 객체에 담겨 있음
-        String username = authentication.getName(); // Basic Auth에서 username 추출
+        // 여기서 authentication의 principal === UserDetails 객체
+//        String username = authentication.getName(); // Basic Auth에서 username 추출
 //		String password = (String) authentication.getCredentials(); // Basic Auth에서 password 추출
 
-        // 4. 인증 성공 시 JWT 토큰 생성
+        // 2. 인증 성공 시 JWT 토큰 생성
         // authentication이 이미 인증된 상태라면 불필요한 authenticate() 호출을 방지
-        logger.info("Login successful for user: {}", username);
+        logger.info("Login successful for username: {}", authentication.getName()); // 여기선 UserDetails의 username
         Jwt accessToken = jwtTokenProvider.createToken(authentication); // JWT 토큰 생성
 
         ResponseCookie accessTokenCookie = jwtTokenProvider.makeResponseCookie("access_token", accessToken.getTokenValue());
@@ -169,10 +166,6 @@ public class AuthController {
 
     // TODO 
     //  - Nextjs 프론트엔드 프로젝트 쪽으로 기능 분리
-    /*@GetMapping(value = { "/signup" })
-    public String signupPage() {
-        return "signup";
-    }*/
 
     //	@PreAuthorize("hasAuthority('ADMIN') and #user.username == authentication.name")
    /* @PreAuthorize("hasAuthority('ADMIN')")

--- a/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
+++ b/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
@@ -1,6 +1,6 @@
 package com.test.basic.auth.csrf;
 
-import org.springframework.context.annotation.Profile;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@Profile("test") // test 환경에서만 활성화됨
 @RequestMapping("/csrf")
+@Tag(name = "CSRF API", description = "CSRF 토큰 발급 API")
 public class CsrfTokenController {
 
     // RestTemplate이나 테스트 환경에선 CSRF 자동 관리가 안돼서 테스트용으로 만든 API

--- a/src/main/java/com/test/basic/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/test/basic/auth/jwt/JwtTokenProvider.java
@@ -1,14 +1,10 @@
 package com.test.basic.auth.jwt;
 
-import com.test.basic.auth.security.CustomUserDetailsService;
+import com.test.basic.auth.security.user.CustomUserDetails;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseCookie;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.stereotype.Component;
 
@@ -25,8 +21,6 @@ public class JwtTokenProvider {
     private static final long ACCESS_TOKEN_EXPIRY = 3600L;
     private static final long REFRESH_TOKEN_EXPIRY = 3600L;
 
-    /*@Autowired
-    private CustomUserDetailsService customUserDetailsService;*/
 
     public JwtTokenProvider(JwtEncoder encoder, JwtDecoder decoder) throws Exception {
         this.encoder = encoder;
@@ -41,22 +35,34 @@ public class JwtTokenProvider {
 
     public Jwt makeAccessToken(Authentication authentication) {
         Instant now = Instant.now();
-        // @formatter:off
         String scope = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(" "));
 
-        // FIXME CLAIM에 SCOPE 정보 제외시키기
-        //  최소한의 정보만 JWT에 포함시켜야 함. (EX. username)
-        // 클레임(payload)
+        String userId, email, username;
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomUserDetails userDetails) {
+            userId = userDetails.getId().toString();
+            email = userDetails.getEmail();
+            username = userDetails.getUsername();
+        } else if (principal instanceof Jwt jwt) {
+            userId = jwt.getSubject();
+            email = jwt.getClaimAsString("email");
+            username = jwt.getClaimAsString("username");
+        } else {
+            throw new IllegalStateException("Unknown principal type: " + principal.getClass());
+        }
+
         JwtClaimsSet claims = JwtClaimsSet.builder()
-                .issuer("self")	// JWT를 발급한 주체
-                .issuedAt(now)	// JWT가 발급된 시간
-                .expiresAt(now.plusSeconds(ACCESS_TOKEN_EXPIRY))	// JWT의 만료 시간 (현재 시간 + expiry 초)
-                .subject(authentication.getName())	// JWT의 주체 (여기서는 인증된 사용자의 이름)
-                .claim("scope", scope)	// 사용자가 가진 권한
+                .issuer("self")
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(ACCESS_TOKEN_EXPIRY))
+                .subject(userId)
+                .claim("email", email)
+                .claim("username", username)
+                .claim("scope", scope) // FIXME: 필요한 경우 제외
                 .build();
-        // @formatter:on
 
         return this.encoder.encode(JwtEncoderParameters.from(claims));
     }
@@ -69,7 +75,7 @@ public class JwtTokenProvider {
                 .issuer("self")  // JWT를 발급한 주체
                 .issuedAt(now)    // JWT가 발급된 시간
                 .expiresAt(now.plusSeconds(REFRESH_TOKEN_EXPIRY))  // 리프레시 토큰의 만료 시간 (몇 일 뒤)
-                .subject(authentication.getName())   // 주체 (사용자 정보)
+                .subject(authentication.getName())   // 주체 (사용자 정보). 여기서는 jwt.getClaim("sub") 값 == userId
                 .claim("type", "refresh") // 리프레시 토큰 구분을 위한 "type" 클레임
                 .build();
 
@@ -124,15 +130,4 @@ public class JwtTokenProvider {
             return false;  // 예외 발생 시 토큰이 유효하지 않음
         }
     }
-
-    // jwt 토큰 기반 사용자 검증
-    /*public Authentication getAuthentication(String token) {
-        Jwt jwt = this.decoder.decode(token);
-
-        String username = jwt.getSubject();
-        UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
-
-        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
-    }*/
-
 }

--- a/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.test.basic.auth.jwt.CustomJwtFilter;
 import com.test.basic.auth.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -41,11 +42,13 @@ import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.regex.Pattern;
 
 /**
  * Security configuration for the main application.
@@ -87,9 +90,12 @@ public class SecurityConfig {
 				.addFilterBefore(new CustomJwtFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)
 
 				// 특정 요청에서 CSRF 해제
-				.csrf((csrf) -> csrf.ignoringRequestMatchers(
-						"/auth/login", "/auth/signup", "/auth/token/refresh"
-				))
+				.csrf((csrf) -> csrf
+						.ignoringRequestMatchers(
+							"/auth/login", "/auth/signup", "/auth/token/refresh"
+						)
+						.requireCsrfProtectionMatcher(new CsrfRequireMatcher())
+				)
 				// Basic Authentication 인증 설정
 //				.httpBasic(Customizer.withDefaults())	// Basic Authentication 활성화
 				// basic 인증 실패 시 뜨는 id/pw 재인증 팝업 방지를 위해 커스텀 엔트리 포인트 설정
@@ -200,6 +206,29 @@ public class SecurityConfig {
 					.allowedMethods(ALLOWED_METHOD_NAMES.split(","))	// 허용할 HTTP 메서드
 					.allowedHeaders("Authorization", "Content-Type")
 					.allowCredentials(true);	// JWT 등 인증 정보(쿠키) 포함 허용 (credentials: 'include'가 포함된 요청 허용)
+		}
+	}
+
+
+	// Spring Security의 CSRF 보호 기능이 어떤 요청에 적용될지를 커스터마이징하는 필터 역할
+	// 특정 요청에 대한 csrf 토큰 검사 진행 여부를 true/false로 리턴해줌
+	// 참고) https://jeonyoungho.github.io/posts/Open-API-3.0-Swagger-v3/
+	static class CsrfRequireMatcher implements RequestMatcher {
+		// POST, PUT, DELETE처럼 상태를 바꾸는 메서드만 검사 대상으로 선정
+		private static final Pattern ALLOWED_METHODS = Pattern.compile("^(GET|HEAD|TRACE|OPTIONS)$");
+
+		// 모든 요청 하나하나에 대해 호출되며 true -> CSRF 검사 O. false -> 검사 X.
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			if (ALLOWED_METHODS.matcher(request.getMethod()).matches())
+				return false;
+
+			// request를 보낸 페이지 url에 /swagger-ui url이 포함되어있다면 CORS 처리 X
+			final String referer = request.getHeader("Referer");
+			if (referer != null && referer.contains("/swagger-ui")) {
+				return false;
+			}
+			return true;
 		}
 	}
 

--- a/src/main/java/com/test/basic/auth/security/user/CustomUserDetails.java
+++ b/src/main/java/com/test/basic/auth/security/user/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.test.basic.auth.security.user;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+/*
+    Spring Security가 JWT 파싱한 후, Authentication 객체로 주입할 때
+    그 안에 들어가는 Principal로 UserDetails 타입 데이터를 등록할 수 있음
+    그래서 @AuthenticationPrincipal 쓰려면
+    우리가 커스텀해서 원하는 필드(예: email, userId 등)를 담은 CustomUserDetails 클래스가 필요해.
+    => JWT 기반 인증 후 사용자 정보 바로 꺼낼 수 있음
+ */
+public class CustomUserDetails implements UserDetails {
+
+    @Getter
+    private final Long id;
+    @Getter
+    private final String email;
+    private final String password;
+    private final String username;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long id, String email, String password, String username, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.username = username;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/test/basic/auth/security/user/CustomUserDetailsService.java
+++ b/src/main/java/com/test/basic/auth/security/user/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.test.basic.auth.security;
+package com.test.basic.auth.security.user;
 
 import com.test.basic.users.UserEntity;
 import com.test.basic.users.UserRepository;
@@ -30,6 +30,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     @Transactional
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 이메일 기반으로 사용자 조회
+        return loadUserByEmail(email);
+    }
+
+    @Transactional
+    public UserDetails loadUserByEmail(String email) throws UsernameNotFoundException {
         // 사용자 정보를 DB에서 조회
         UserEntity user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
@@ -41,15 +47,19 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 
-        // username 대신 email 사용해서 인증
-        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), grantedAuthorities);
+        return new CustomUserDetails(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                user.getName(),
+                grantedAuthorities
+        );
     }
 
-
-    private Collection<? extends GrantedAuthority> getAuthorities(UserEntity user) {
+    /*private Collection<? extends GrantedAuthority> getAuthorities(UserEntity user) {
         // 예: DB에 저장된 역할을 기반으로 Authorities 객체 생성
         return Arrays.stream(user.getAuthority().split(","))
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
-    }
+    }*/
 }

--- a/src/main/java/com/test/basic/common/handler/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/test/basic/common/handler/JwtHandshakeInterceptor.java
@@ -4,6 +4,7 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
@@ -17,11 +18,15 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         // SecurityContext에서 인증 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Jwt jwt = (Jwt) authentication.getPrincipal();
+        String userId = authentication.getName();   // === jwt.getClaim("sub")
+        String username = jwt.getClaimAsString("username");
 
         if (authentication != null) {
             // WebSocketSession에 인증 정보 저장
             attributes.put("authentication", authentication);
-            attributes.put("username", authentication.getName());
+            attributes.put("userId", userId);
+            attributes.put("username", username);
         }
 
         return true; // Handshake 계속 진행

--- a/src/test/java/com/test/basic/auth/crypto/RSAControllerTest.java
+++ b/src/test/java/com/test/basic/auth/crypto/RSAControllerTest.java
@@ -3,11 +3,14 @@ package com.test.basic.auth.crypto;
 import com.nimbusds.jose.util.Base64;
 import com.test.basic.auth.AuthController;
 import com.test.basic.auth.jwt.JwtTokenProvider;
-import com.test.basic.auth.security.CustomUserDetailsService;
 import com.test.basic.auth.security.config.SecurityConfig;
+import com.test.basic.auth.security.user.CustomUserDetails;
+import com.test.basic.auth.security.user.CustomUserDetailsService;
 import com.test.basic.users.UserService;
 import jakarta.servlet.http.Cookie;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +19,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -53,10 +57,13 @@ public class RSAControllerTest {
         logger.info("======================================================");
         logger.info("...테스트용 관리자 계정 로그인 및 JWT 토큰 발급");
         logger.info("======================================================");
-        UserDetails mockUser = User.withUsername("admin")
-                .password("$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy")
-                .authorities("ADMIN")
-                .build();
+        UserDetails mockUser = new CustomUserDetails(
+                1L, // 혹은 UUID.randomUUID()
+                "admin",           // email
+                "$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy", // password
+                "admin",           // username
+                List.of(new SimpleGrantedAuthority("SCOPE_ADMIN"))
+        );
 
         when(customUserDetailsService.loadUserByUsername(mockUser.getUsername())).thenReturn(mockUser);
 

--- a/src/test/java/com/test/basic/users/UserControllerTest.java
+++ b/src/test/java/com/test/basic/users/UserControllerTest.java
@@ -3,11 +3,12 @@ package com.test.basic.users;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.util.Base64;
 import com.test.basic.auth.AuthController;
-import com.test.basic.auth.jwt.JwtTokenProvider;
-import com.test.basic.auth.security.CustomUserDetailsService;
-import com.test.basic.auth.security.config.SecurityConfig;
-import com.test.basic.common.utils.RSAUtil;
 import com.test.basic.auth.csrf.CsrfTokenController;
+import com.test.basic.auth.jwt.JwtTokenProvider;
+import com.test.basic.auth.security.config.SecurityConfig;
+import com.test.basic.auth.security.user.CustomUserDetails;
+import com.test.basic.auth.security.user.CustomUserDetailsService;
+import com.test.basic.common.utils.RSAUtil;
 import jakarta.servlet.http.Cookie;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -114,10 +115,13 @@ public class UserControllerTest {
         logger.info("======================================================");
         logger.info("...테스트용 관리자 계정 로그인 및 JWT 토큰 발급");
         logger.info("======================================================");
-        UserDetails mockUser = User.withUsername("admin")
-                .password("$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy")
-                .authorities("ADMIN")
-                .build();
+        UserDetails mockUser = new CustomUserDetails(
+                1L, // 혹은 UUID.randomUUID()
+                "admin",           // email
+                "$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy", // password
+                "admin",           // username
+                List.of(new SimpleGrantedAuthority("SCOPE_ADMIN"))
+        );
 
         when(customUserDetailsService.loadUserByUsername(mockUser.getUsername())).thenReturn(mockUser);
 

--- a/src/test/java/com/test/basic/users/UserIntegrationTest.java
+++ b/src/test/java/com/test/basic/users/UserIntegrationTest.java
@@ -1,7 +1,8 @@
 package com.test.basic.users;
 
 import com.test.basic.auth.jwt.JwtTokenProvider;
-import com.test.basic.auth.security.CustomUserDetailsService;
+import com.test.basic.auth.security.user.CustomUserDetails;
+import com.test.basic.auth.security.user.CustomUserDetailsService;
 import com.test.basic.common.handler.AcceptanceTestExecutionListener;
 import com.test.basic.common.utils.RSAUtil;
 import org.junit.jupiter.api.*;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ActiveProfiles;
@@ -88,10 +90,13 @@ public class UserIntegrationTest {
         logger.info("...테스트용 관리자 계정 로그인 및 JWT 토큰 발급");
         logger.info("======================================================");
 
-        UserDetails mockUser = User.withUsername("admin")
-                .password("$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy")
-                .authorities("ADMIN")
-                .build();
+        UserDetails mockUser = new CustomUserDetails(
+                1L, // 혹은 UUID.randomUUID()
+                "admin",           // email
+                "$2b$12$JgK.Du5J.DbMQ6zQ1Tx58OoKCEGr3NUG.p45zDQb0qALy9T5MczJy", // password
+                "admin",           // username
+                List.of(new SimpleGrantedAuthority("SCOPE_ADMIN"))
+        );
 
         when(customUserDetailsService.loadUserByUsername(mockUser.getUsername())).thenReturn(mockUser);
 


### PR DESCRIPTION
1. refactor(jwt)
- JWT subject 값을 username → id(PK)로 변경
- Authentication.getPrincipal()에서 사용자 정보 추출하는 로직 분리
- 불필요한 코드 제거로 구조 간소화

2. chore(csrf)
- @Profile 태그 제거로 CSRF 설정 항상 적용되도록 수정
- 특정 요청(Swagger 등)에 대해 CSRF 검사 제외하도록 CsrfRequireMatcher 구현

3. feat(사용자인증)
- 사용자 인증 정보 클래스를 CustomUserDetails로 교체
- CustomUserDetailsService에서 해당 객체 반환하도록 변경
- Spring Security가 사용자 조회 시 email 기준으로 찾도록 변경

4. feat(채팅)
- 채팅 기능에서 사용자 식별 위해 id 필드 추가

5. test
- 사용자 인증 정보가 User → CustomUserDetails로 바뀐 흐름에 맞게 테스트 코드 수정
