### PR TITLE
1. feat: 인증 및 API 문서 설정 개선 (CSRF, 쿠키, Swagger 설정 등 전반적 개선) 등

### DIFF
--- a/src/main/java/com/test/basic/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/test/basic/auth/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.test.basic.auth.jwt;
 
 import com.test.basic.auth.security.user.CustomUserDetails;
 import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,6 +17,13 @@ import java.util.stream.Collectors;
 
 @Component
 public class JwtTokenProvider {
+
+    @Value("${cookie.secure}")
+    private boolean isSecure;
+
+    @Value("${cookie.same-site}")
+    private String sameSite;
+
 
     private static JwtEncoder encoder;
     private static JwtDecoder decoder;
@@ -96,11 +104,10 @@ public class JwtTokenProvider {
         //  그 후의 요청에서 그 쿠키를 자동으로 포함시켜 서버로 보낸다
         ResponseCookie cookie = ResponseCookie.from(key, token)
                 .httpOnly(true)  // 클라이언트 JS에서 접근 불가능. XSS 공격이 JWT를 읽을 수 없으므로 보안성이 향상
-                .secure(true)    // HTTPS에서만 전송. false: HTTP 허용
+                .secure(isSecure)    // true: HTTPS에서만 전송. false: HTTP 허용
                 .path("/")       // 모든 경로에서 쿠키 사용 가능
                 .maxAge(ACCESS_TOKEN_EXPIRY)    // 만료 시간 설정
-                .sameSite("Lax")    // GET 메소드 요청에 한해 CORS 허용
-//                .sameSite("None")  // CORS 환경에서 사용 가능하도록 설정 (필요하면 변경 가능). 크로스 사이트 요청에서 쿠키 전송
+                .sameSite(sameSite)    // Lax: GET 메소드 요청에 한해 CORS 허용. None: 모든 요청에 CORS 허용.
                 .build();
 
         return cookie;

--- a/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
@@ -44,6 +44,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -96,7 +97,9 @@ public class SecurityConfig {
 				// 특정 요청에서 CSRF 해제
 				.csrf((csrf) -> csrf
 						.ignoringRequestMatchers(
-							"/auth/login", "/auth/signup", "/auth/token/refresh"
+							new AntPathRequestMatcher("/auth/login"),
+							new AntPathRequestMatcher("/auth/signup"),
+							new AntPathRequestMatcher("/auth/token/refresh")
 						)
 						.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // httpOnly: false (JS에서 읽을 수 있도록)
 						.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())	// 토큰 해석기 지정(spring security 6~)
@@ -210,7 +213,8 @@ public class SecurityConfig {
 							"https://ec2-54-180-118-74.ap-northeast-2.compute.amazonaws.com"
 					) // 허용할 프론트엔드 도메인
 					.allowedMethods(ALLOWED_METHOD_NAMES.split(","))	// 허용할 HTTP 메서드
-					.allowedHeaders("Authorization", "Content-Type")
+					.allowedHeaders("Content-Type", "Authorization", "X-XSRF-TOKEN", "X-From-Swagger") 	// 클라이언트가 보낼 수 있는 헤더
+					.exposedHeaders("X-XSRF-TOKEN")	// 클라이언트가 응답에서 읽을 수 있는 헤더
 					.allowCredentials(true);	// JWT 등 인증 정보(쿠키) 포함 허용 (credentials: 'include'가 포함된 요청 허용)
 		}
 	}
@@ -226,8 +230,11 @@ public class SecurityConfig {
 					return false;
 				}
 
-				String referer = request.getHeader("Referer");
-				return referer == null || !referer.contains("/swagger-ui");
+				// swagger 전용 헤더가 포함되어있다면 CORS 처리 X
+				if (request.getHeader("X-From-Swagger") != null) {
+					return false;	// CSRF 보호를 건너뜀
+				}
+				return true;	// 나머지 요청은 CSRF 보호 유지
 			}
 		};
 	}

--- a/src/main/java/com/test/basic/lol/teams/TeamController.java
+++ b/src/main/java/com/test/basic/lol/teams/TeamController.java
@@ -2,6 +2,7 @@ package com.test.basic.lol.teams;
 
 import com.test.basic.lol.batch.TeamBatchService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ public class TeamController {
 
     @PostMapping("/sync-teams")
     @PreAuthorize("hasAuthority('ADMIN')")
+    @SecurityRequirement(name = "IgnoreCSRF")
     @Operation(summary = "LOL 팀 정보 수동 동기화", description = "LOL 팀 정보 수동 동기화 API")
     public ResponseEntity<String> syncTeams() {
         logger.info("[DEV][팀 수동 동기화] LoL Esports API로부터 팀 정보 동기화 시작");

--- a/src/main/java/com/test/basic/swagger/SwaggerConfig.java
+++ b/src/main/java/com/test/basic/swagger/SwaggerConfig.java
@@ -1,11 +1,15 @@
-package com.test.basic.common.config;
+package com.test.basic.swagger;
 
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +28,13 @@ import java.util.List;
         scheme = "bearer",
         bearerFormat = "JWT"
 )
-public class ApiDocConfig {
+@SecurityScheme(
+        name = "IgnoreCSRF",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = "X-From-Swagger"
+)
+public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         Info info = new Info()

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -37,9 +37,16 @@ springdoc.api-docs.groups.enabled=true
 # Swagger UI 모델 깊이 설정
 springdoc.swagger-ui.default-model-expand-depth=1
 springdoc.swagger-ui.default-models-expand-depth=1
+springdoc.swagger-ui.csrf.enabled=true
+springdoc.swagger-ui.with-credentials=true
 
 # Redis 설정
 spring.data.redis.host=54.180.118.74
 spring.data.redis.port=36379
 spring.data.redis.password=jikim_pwdForRedis_250419
 spring.data.redis.timeout=2000
+
+# 배포 시 https 요청에서만 쿠키 저장
+cookie.secure=true
+# GET 요청 외 CSRF 토큰 검증 필요
+cookie.same-site=Lax

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,14 @@ lol:
       url: https://esports-api.lolesports.com
       key: 0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z
 
+# 쿠키 정책 설정 (로컬 http/https 프론트 <-> 로컬 http 백엔드)
+cookie:
+  secure: true
+  same-site: None
+
+springdoc:
+  swagger-ui:
+    csrf:
+      enabled: true
+    with-credentials: true
+    filter: true


### PR DESCRIPTION
- JWT 쿠키 정책 옵션(secure, sameSite)을 환경변수로 분리하여 개발/배포 환경 대응 
- Swagger UI 설정에 CSRF, with-credentials, 필터 기능 활성화 옵션 추가
- SecurityConfig에서 CSRF 예외 경로에 antPathRequestMatcher 적용, CORS 요청 헤더 허용 추가
- Swagger 요청 시 CSRF 우회를 위한 전용 헤더 처리 로직 추가

2. chore: Swagger 설정 클래스 이름 및 경로 변경 (ApiDocConfig → SwaggerConfig)