### PR TITLE
1. [Refactor] LOL Esports API 설정 및 WebClient 호출 로직 분리

### DIFF
--- a/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
+++ b/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
@@ -7,10 +7,10 @@ import com.test.basic.lol.matches.TeamMatchResult;
 import com.test.basic.lol.teams.Team;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ public class LolEsportsApiClient {
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
-    private final String esportsApiKey;
+    private final String API_KEY;
 
     private static final String HL = "ko-KR";
     private static final String LEAGUE_ID = "98767991310872058"; // LCK
@@ -34,8 +34,7 @@ public class LolEsportsApiClient {
     @Autowired
     public LolEsportsApiClient(
             WebClient.Builder webClientBuilder,
-            @Value("${lol.esports.api.url}") String apiBaseUrl,
-            @Value("${lol.esports.api.key}") String esportsApiKey
+            LolEsportsApiConfig apiConfig
     ) {
 
         // WebClient가 받아들이는 응답 크기 제한
@@ -46,29 +45,26 @@ public class LolEsportsApiClient {
                 .build();
 
         this.webClient = webClientBuilder
-                .baseUrl(apiBaseUrl)
+                .baseUrl(apiConfig.getUrl())
                 .exchangeStrategies(strategies)
                 .build();
         this.objectMapper = new ObjectMapper();
-        this.esportsApiKey = esportsApiKey;
+        this.API_KEY = apiConfig.getKey();
     }
 
-    public List<MatchDto> fetchScheduleMatches() {
-        String response = webClient.get()
+    public Mono<String> fetchScheduleMatches() {
+        return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/persisted/gw/getSchedule")
                         .queryParam("hl", HL)
                         .queryParam("leagueId", LEAGUE_ID)
                         .build())
-                .header("x-api-key", esportsApiKey)
+                .header("x-api-key", API_KEY)
                 .retrieve()
-                .bodyToMono(String.class)
-                .block();
-
-        return parseMatchesFromResponse(response);
+                .bodyToMono(String.class);
     }
 
-    private List<MatchDto> parseMatchesFromResponse(String response) {
+    public List<MatchDto> parseMatchesFromResponse(String response) {
         List<MatchDto> result = new ArrayList<>();
 
         try {
@@ -115,7 +111,7 @@ public class LolEsportsApiClient {
                         .path("/persisted/gw/getTeams")
                         .queryParam("hl", HL)
                         .build())
-                .header("x-api-key", esportsApiKey)
+                .header("x-api-key", API_KEY)
                 .retrieve()
                 .bodyToMono(String.class)   // 전체 응답을 스트리밍 방식으로 처리
                 .block();
@@ -130,7 +126,7 @@ public class LolEsportsApiClient {
                         .queryParam("hl", HL)
                         .queryParam("id", slug)
                         .build())
-                .header("x-api-key", esportsApiKey)
+                .header("x-api-key", API_KEY)
                 .retrieve()
                 .bodyToMono(String.class)   // 전체 응답을 스트리밍 방식으로 처리
                 .block();

--- a/src/main/java/com/test/basic/lol/api/LolEsportsApiConfig.java
+++ b/src/main/java/com/test/basic/lol/api/LolEsportsApiConfig.java
@@ -1,0 +1,28 @@
+package com.test.basic.lol.api;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "lol.esports.api")
+public class LolEsportsApiConfig {
+    private String url;
+    private String key;
+
+    // Getter와 Setter
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/src/main/java/com/test/basic/lol/matches/MatchService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchService.java
@@ -31,7 +31,8 @@ public class MatchService {
         }
 
         // TTL 지났거나 최초 요청이면 새로 로딩
-        cachedMatches = apiClient.fetchScheduleMatches();
+        String response = apiClient.fetchScheduleMatches().block();
+        cachedMatches = apiClient.parseMatchesFromResponse(response);
         lastFetchedTime = Instant.now();
         return cachedMatches;
     }

--- a/src/test/java/com/test/basic/lol/api/LolEsportsApiClientIntergrationTest.java
+++ b/src/test/java/com/test/basic/lol/api/LolEsportsApiClientIntergrationTest.java
@@ -1,0 +1,33 @@
+package com.test.basic.lol.api;
+
+import com.test.basic.lol.matches.MatchDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LolEsportsApiClientIntergrationTest {
+
+    @Autowired
+    private LolEsportsApiClient lolEsportsApiClient;
+
+    @Test
+    void testFetchScheduleMatchesIntegration() {
+        // 실제로 HTTP 요청 보내는 테스트 (실서버가 아니면 WireMock 등으로 가짜 서버 띄워야 안전)
+        Mono<String> result = lolEsportsApiClient.fetchScheduleMatches();
+
+        String jsonResponse = result.block();
+
+        assertThat(jsonResponse).isNotNull();
+
+        List<MatchDto> matches = lolEsportsApiClient.parseMatchesFromResponse(jsonResponse);
+
+        assertThat(matches).isNotNull();
+        assertThat(matches.size()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/test/basic/lol/api/LolEsportsApiClientUnitTest.java
+++ b/src/test/java/com/test/basic/lol/api/LolEsportsApiClientUnitTest.java
@@ -1,0 +1,124 @@
+package com.test.basic.lol.api;
+
+import com.test.basic.lol.matches.MatchDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)  // Mockito 확장 기능을 활성화
+public class LolEsportsApiClientUnitTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;  // WebClient.Builder Mock 객체
+
+    @Mock
+    private WebClient webClient;  // WebClient Mock 객체
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;  // URI 요청 Mock 객체
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;  // 응답 Spec Mock 객체
+
+    @Mock
+    private LolEsportsApiConfig lolEsportsApiConfig;
+
+    private LolEsportsApiClient lolEsportsApiClient;
+
+    private static String MOCK_JSON_RESPONSE;
+
+    @BeforeAll
+    static void setupMockJsonResponse() {
+        MOCK_JSON_RESPONSE  = "{\n" +
+                "  \"data\": {\n" +
+                "    \"schedule\": {\n" +
+                "      \"events\": [\n" +
+                "        {\n" +
+                "          \"startTime\": \"2025-04-28T12:00:00Z\",\n" +
+                "          \"state\": \"completed\",\n" +
+                "          \"match\": {\n" +
+                "            \"teams\": [\n" +
+                "              { \"code\": \"team1\", \"name\": \"Team 1\", \"result\": {\"outcome\": \"win\"} },\n" +
+                "              { \"code\": \"team2\", \"name\": \"Team 2\", \"result\": {\"outcome\": \"lose\"} }\n" +
+                "            ]\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+    }
+
+    @BeforeEach
+    public void setup() {
+
+        // WebClient.Builder의 메서드 체이닝을 모킹
+        when(lolEsportsApiConfig.getUrl()).thenReturn("testUrl");
+        when(lolEsportsApiConfig.getKey()).thenReturn("testKey");
+        when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        when(webClientBuilder.exchangeStrategies(any(ExchangeStrategies.class))).thenReturn(webClientBuilder);  // exchangeStrategies를 Mock
+        when(webClientBuilder.build()).thenReturn(webClient);  // build() 메서드 호출 시, Mock된 WebClient 반환
+
+        // Mocking WebClient Builder 및 WebClient 설정
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        // uri() 메서드의 Function<UriBuilder, URI> 람다를 **Answer**로 처리
+        when(requestHeadersUriSpec.uri(Mockito.any(Function.class))).thenAnswer(invocation -> {
+            Function<UriBuilder, URI> uriFunction = invocation.getArgument(0);
+
+            // UriBuilder를 mock으로 생성
+            UriBuilder uriBuilder = mock(UriBuilder.class);
+
+            // [핵심] path, queryParam 호출하면 자기 자신 반환하게 설정
+            when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+            when(uriBuilder.queryParam(anyString(), anyString())).thenReturn(uriBuilder);
+
+            // [핵심] build() 호출하면 정상 URI 반환
+            when(uriBuilder.build()).thenReturn(URI.create("http://localhost/test"));
+
+            // 이제 람다 실행
+            URI uri = uriFunction.apply(uriBuilder);
+
+            // URI가 null이 아님을 확인
+            assertNotNull(uri);
+            return requestHeadersUriSpec; // 스텁 결과
+        });
+
+        when(requestHeadersUriSpec.header("x-api-key", lolEsportsApiConfig.getKey())).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just(MOCK_JSON_RESPONSE));
+
+        lolEsportsApiClient = new LolEsportsApiClient(webClientBuilder, lolEsportsApiConfig);
+    }
+
+    @Test
+    void testFetchScheduleMatches() {
+        // fetchScheduleMatches() 메서드를 호출하여 반환값을 확인
+        Mono<String> result = lolEsportsApiClient.fetchScheduleMatches();
+
+        // block()으로 결과 값을 동기적으로 받습니다.
+        String jsonResponse = result.block();
+
+        // parseMatchesFromResponse가 JSON String을 받아서 파싱을 진행하도록 설정
+        List<MatchDto> matches = lolEsportsApiClient.parseMatchesFromResponse(jsonResponse);
+
+        // 결과가 비어 있지 않으며, 예상한 크기 이상인지를 확인
+        assertThat(matches).isNotNull();
+        assertThat(matches.size()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/test/basic/sample/api/ExternalApiService.java
+++ b/src/test/java/com/test/basic/sample/api/ExternalApiService.java
@@ -1,0 +1,34 @@
+package com.test.basic.sample.api;
+
+import com.test.basic.lol.api.LolEsportsApiConfig;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class ExternalApiService {
+
+    private final WebClient webClient;
+
+    public ExternalApiService(WebClient.Builder webClientBuilder, LolEsportsApiConfig config) {
+        // WebClient가 받아들이는 응답 크기 제한
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(2 * 1024 * 1024)) // 최대 2MB로 설정 (필요하면 더)
+                .build();
+
+        this.webClient = webClientBuilder.baseUrl(config.getUrl())
+                .exchangeStrategies(strategies)
+                .build();  // JSONPlaceholder API 사용
+    }
+
+    // 간단한 GET 요청을 보내고 응답을 반환하는 메서드
+    public Mono<String> fetchData() {
+        return webClient.get()
+                .uri("/todos/1")  // 간단한 TODO API 호출
+                .retrieve()
+                .bodyToMono(String.class);  // 응답을 String으로 받음
+    }
+}

--- a/src/test/java/com/test/basic/sample/api/ExternalExternalApiServiceTest.java
+++ b/src/test/java/com/test/basic/sample/api/ExternalExternalApiServiceTest.java
@@ -1,0 +1,70 @@
+package com.test.basic.sample.api;
+
+import com.test.basic.lol.api.LolEsportsApiConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * WebClient, RequestHeadersUriSpec, ResponseSpec 전부 모킹
+ * 실제 HTTP 안 나감
+ */
+@ExtendWith(MockitoExtension.class)  // Mockito 확장 기능을 활성화
+public class ExternalExternalApiServiceTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;  // WebClient.Builder Mock 객체
+
+    @Mock
+    private WebClient webClient;  // WebClient Mock 객체
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;  // URI 요청 Mock 객체
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;  // 응답 Spec Mock 객체
+
+    @Mock
+    private LolEsportsApiConfig config;  // 응답 Spec Mock 객체
+
+    private ExternalApiService externalApiService;  // 테스트 대상 서비스 클래스
+
+    @BeforeEach
+    public void setup() {
+        // WebClient.Builder에서 WebClient를 빌드할 때 Mock WebClient를 반환하도록 설정
+        when(config.getUrl()).thenReturn("https://jsonplaceholder.typicode.com");
+        when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        when(webClientBuilder.exchangeStrategies(any(ExchangeStrategies.class))).thenReturn(webClientBuilder);  // exchangeStrategies를 Mock
+        when(webClientBuilder.build()).thenReturn(webClient);  // build() 메서드 호출 시, Mock된 WebClient 반환
+
+        // WebClient의 동작을 설정
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);  // get() 호출 시, requestHeadersUriSpec 반환
+        when(requestHeadersUriSpec.uri("/todos/1")).thenReturn(requestHeadersUriSpec);  // URI 설정
+        when(requestHeadersUriSpec.retrieve()).thenReturn(responseSpec);  // retrieve() 호출 시, responseSpec 반환
+        when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just("{\"userId\": 1, \"id\": 1, \"title\": \"delectus aut autem\", \"completed\": false}"));  // 응답 설정
+
+        externalApiService = new ExternalApiService(webClientBuilder, config);  // Mock된 WebClient.Builder를 사용하여 ApiService 인스턴스 생성
+    }
+
+    @Test
+    void testFetchData() {
+        // fetchData 메서드를 호출하여 응답을 받음
+        Mono<String> result = externalApiService.fetchData();
+
+        // Mono의 결과를 가져와서 검증
+        String response = result.block();  // block()을 사용하여 결과를 동기적으로 가져옴
+
+        // 결과가 null이 아니고, 예상한 JSON 응답이 포함된 문자열인지 검증
+        assertThat(response).isNotNull();
+        assertThat(response).contains("\"userId\": 1");
+        assertThat(response).contains("\"title\": \"delectus aut autem\"");
+    }
+}


### PR DESCRIPTION
- API URL, KEY Config 클래스로 분리
- WebClient 호출과 JSON 파싱 로직 분리

2. [Feat] LOL Esports API 단위 및 통합 테스트 추가
- WebClient 모킹 단위 테스트 작성
- WebClient 요청 테스트 샘플 코드 추가