### PR TITLE
1. [Feat] 토너먼트 및 토너먼트별 순위 조회 API 구현

### DIFF
--- a/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
+++ b/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
@@ -151,4 +151,29 @@ public class LolEsportsApiClient {
         }
     }
 
+    public Mono<String> fetchTournaments() {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/persisted/gw/getTournamentsForLeague")
+                        .queryParam("hl", HL)
+                        .queryParam("leagueId", LEAGUE_ID)
+                        .build())
+                .header("x-api-key", API_KEY)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    // 현재 날짜 기준으로 진행중인 토너먼트 있으면 해당 토너먼트 id 순위 조회
+    public Mono<String> fetchStandins(String tournamentId) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/persisted/gw/getStandings")
+                        .queryParam("hl", HL)
+                        .queryParam("tournamentId", tournamentId)
+                        .build())
+                .header("x-api-key", API_KEY)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
 }

--- a/src/main/java/com/test/basic/lol/standings/StandingsController.java
+++ b/src/main/java/com/test/basic/lol/standings/StandingsController.java
@@ -1,0 +1,31 @@
+package com.test.basic.lol.standings;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/lol/standings")
+@Tag(name = "LOL 리그 순위 API", description = "LOL 리그 순위 API")
+public class StandingsController {
+
+    private final StandingsService standingsService;
+
+    public StandingsController(StandingsService standingsService) {
+        this.standingsService = standingsService;
+    }
+
+    @GetMapping("/{tournamentId}")
+    @Operation(summary = "토너먼트별 순위 조회", description = "토너먼트별 순위 조회 API")
+    public ResponseEntity<List> getStandings(@PathVariable String tournamentId) {
+        List<StandingsDto> standings = standingsService.getStandingsByTournamentId(tournamentId);
+        return ResponseEntity.ok(standings);
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/standings/StandingsDto.java
+++ b/src/main/java/com/test/basic/lol/standings/StandingsDto.java
@@ -1,0 +1,17 @@
+package com.test.basic.lol.standings;
+
+import com.test.basic.lol.teams.Team;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StandingsDto {
+    private String id;        // 113503303283548977
+    private String tournamentId;
+    private String name;    // 정규 리그
+    private String slug;    // regular_season
+    private String type;
+
+    private List<Team> rankings;
+}

--- a/src/main/java/com/test/basic/lol/standings/StandingsService.java
+++ b/src/main/java/com/test/basic/lol/standings/StandingsService.java
@@ -1,0 +1,90 @@
+package com.test.basic.lol.standings;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.test.basic.lol.api.LolEsportsApiClient;
+import com.test.basic.lol.teams.Team;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class StandingsService {
+
+    private final LolEsportsApiClient lolEsportsApiClient;
+    private final ObjectMapper objectMapper;
+
+    public StandingsService(LolEsportsApiClient lolEsportsApiClient,
+                            ObjectMapper objectMapper) {
+        this.lolEsportsApiClient = lolEsportsApiClient;;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<StandingsDto> getStandingsByTournamentId(String tournamentId) {
+        Mono<String> result = lolEsportsApiClient.fetchStandins(tournamentId);
+
+        try {
+            JsonNode standingsNodes = objectMapper.readTree(result.block())
+                    .path("data").path("standings");
+
+            List<StandingsDto> standingsList = new ArrayList<>();
+
+            for (JsonNode standings : standingsNodes) {
+                JsonNode stagesArray = standings.path("stages");
+
+                for (JsonNode stage : stagesArray) {
+                    StandingsDto dto = new StandingsDto();
+                    dto.setTournamentId(tournamentId);
+                    dto.setId(stage.path("id").asText());
+                    dto.setName(stage.path("name").asText());
+                    dto.setSlug(stage.path("slug").asText());
+                    dto.setType(stage.path("type").asText(null)); // null safe
+
+                    // rankings: stage.sections[0].rankings
+                    JsonNode sections = stage.path("sections");
+                    if (sections.isArray() && sections.size() > 0) {
+                        List<Team> teamList = new ArrayList<>();
+
+                        JsonNode rankings = sections.get(0).path("rankings");
+                        for (JsonNode rankingNode : rankings) {
+
+                            // 기본 필드들 파싱
+                            String rank = rankingNode.path("ordinal").asText();
+
+                            JsonNode teamNodes = rankingNode.path("teams");
+                            for (JsonNode teamNode : teamNodes) {   // 공동 순위
+                                Team team = new Team();
+
+                                team.setRank(rank);
+                                team.setTeamId(teamNode.path("id").asText());
+                                team.setSlug(teamNode.path("slug").asText());
+                                team.setTeamName(teamNode.path("name").asText());
+                                team.setTeamCode(teamNode.path("code").asText());
+                                team.setImage(teamNode.path("image").asText());
+
+                                // record 파싱
+                                JsonNode recordNode = teamNode.path("record");
+                                int wins = recordNode.path("wins").asInt();
+                                int losses = recordNode.path("losses").asInt();
+                                team.setRecord(wins + "," + losses);
+
+                                teamList.add(team);
+                            }
+                        }
+
+                        dto.setRankings(teamList);
+                    }
+
+                    standingsList.add(dto);
+                }
+            }
+
+            return standingsList;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse data", e);
+        }
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/teams/Team.java
+++ b/src/main/java/com/test/basic/lol/teams/Team.java
@@ -30,6 +30,16 @@ public class Team {
     @Column(name = "home_league", nullable = false)
     private String homeLeague;
 
+    // 테이블에 매핑되지 않는 필드
+    @Transient
+    private String teamId;
+
+    @Transient
+    private String rank;
+
+    @Transient
+    private String record; // "8,0" => 순서대로 win,losses count
+
     public Team(String teamCode, String teamName, String slug, String image, String homeLeague) {
         this.teamCode = teamCode;
         this.teamName = teamName;

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentController.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentController.java
@@ -1,0 +1,29 @@
+package com.test.basic.lol.tournaments;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "토너먼트 API", description = "토너먼트 관련 API")
+@RequestMapping("/lol/tournaments")
+public class TournamentController {
+
+    private final TournamentService tournamentService;
+
+    public TournamentController(TournamentService tournamentService) {
+        this.tournamentService = tournamentService;
+    }
+
+    @GetMapping
+    @Operation(summary = "금년도 토너먼트 목록 조회", description = "금년도 토너먼트 목록 조회 API")
+    public ResponseEntity<List<TournamentDto>> getTournamentsForCurrentYear() {
+        List<TournamentDto> tournaments = tournamentService.getTournamentsForCurrentYear();
+        return ResponseEntity.ok(tournaments);
+    }
+}

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentDto.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentDto.java
@@ -1,0 +1,21 @@
+package com.test.basic.lol.tournaments;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/*{
+    "id": "113503357263583149",
+        "slug": "lck_split_3_2025",
+        "startDate": "2025-07-23",
+        "endDate": "2025-09-28"
+}*/
+@Data
+@NoArgsConstructor
+public class TournamentDto {
+    private String id;
+    private String slug;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentService.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentService.java
@@ -1,0 +1,50 @@
+package com.test.basic.lol.tournaments;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.test.basic.lol.api.LolEsportsApiClient;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class TournamentService {
+
+    private final LolEsportsApiClient lolEsportsApiClient;
+    private final ObjectMapper objectMapper;
+
+    public TournamentService(LolEsportsApiClient lolEsportsApiClient,
+                             ObjectMapper objectMapper) {
+        this.lolEsportsApiClient = lolEsportsApiClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public List<TournamentDto> getTournamentsForCurrentYear() {
+        int currentYear = LocalDate.now().getYear();
+
+        Mono<String> result = lolEsportsApiClient.fetchTournaments();
+
+        try {
+            // 파싱
+            JsonNode tournamentNodes = objectMapper.readTree(result.block())
+                .path("data").path("leagues").get(0).path("tournaments");
+
+            List<TournamentDto> tournaments = new ArrayList<>();
+
+            for (JsonNode tournament : tournamentNodes) {
+                tournaments.add(objectMapper.treeToValue(tournament, TournamentDto.class));
+            }
+
+            return tournaments.stream().filter(tournament ->
+                tournament.getStartDate().getYear() == currentYear
+            ).toList();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse data", e);
+        }
+
+    }
+}


### PR DESCRIPTION
 - LolEsports API 연동을 통한 토너먼트 목록 조회 및 토너먼트별 순위 조회 메서드 추가 
 - 금년도 토너먼트 목록 조회 API 구현 (Controller, Service, DTO 포함) 
 - 토너먼트별 스탠딩 조회 API 구현 (Controller, Service, DTO 포함) 
 - Team 엔티티에 순위 정보 전달용 @Transient 필드 추