### PR TITLE
1. [Refactor] LOL 관련 API에 공통 태그([LOL]) 추가

### DIFF
--- a/src/main/java/com/test/basic/lol/matches/MatchController.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchController.java
@@ -1,6 +1,7 @@
 package com.test.basic.lol.matches;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/lol/matches")
 @RequiredArgsConstructor
+@Tag(name = "[LOL] 경기 일정 API", description = "경기 일정 API")
 public class MatchController {
     private final MatchService matchService;
 

--- a/src/main/java/com/test/basic/lol/standings/StandingsController.java
+++ b/src/main/java/com/test/basic/lol/standings/StandingsController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/lol/standings")
-@Tag(name = "LOL 리그 순위 API", description = "LOL 리그 순위 API")
+@Tag(name = "[LOL] 리그 순위 API", description = "리그 순위 API")
 public class StandingsController {
 
     private final StandingsService standingsService;

--- a/src/main/java/com/test/basic/lol/teams/TeamController.java
+++ b/src/main/java/com/test/basic/lol/teams/TeamController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/lol/teams")
-@Tag(name = "팀 API", description = "팀 관련 API")
+@Tag(name = "[LOL] 팀 API", description = "팀 관련 API")
 public class TeamController {
     private static final Logger logger = LoggerFactory.getLogger(TeamController.class);
 

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentController.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@Tag(name = "토너먼트 API", description = "토너먼트 관련 API")
 @RequestMapping("/lol/tournaments")
+@Tag(name = "[LOL] 토너먼트 API", description = "토너먼트 관련 API")
 public class TournamentController {
 
     private final TournamentService tournamentService;

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentDto.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentDto.java
@@ -18,4 +18,5 @@ public class TournamentDto {
     private String slug;
     private LocalDate startDate;
     private LocalDate endDate;
+    private boolean active;
 }

--- a/src/main/java/com/test/basic/lol/tournaments/TournamentService.java
+++ b/src/main/java/com/test/basic/lol/tournaments/TournamentService.java
@@ -23,7 +23,8 @@ public class TournamentService {
     }
 
     public List<TournamentDto> getTournamentsForCurrentYear() {
-        int currentYear = LocalDate.now().getYear();
+        LocalDate today = LocalDate.now();
+        int currentYear = today.getYear();
 
         Mono<String> result = lolEsportsApiClient.fetchTournaments();
 
@@ -35,12 +36,20 @@ public class TournamentService {
             List<TournamentDto> tournaments = new ArrayList<>();
 
             for (JsonNode tournament : tournamentNodes) {
-                tournaments.add(objectMapper.treeToValue(tournament, TournamentDto.class));
+                TournamentDto dto = objectMapper.treeToValue(tournament, TournamentDto.class);
+
+                if (dto.getStartDate().getYear() != currentYear) continue;
+
+                // 현재 날짜가 startDate ~ endDate 사이에 있으면 isActive 설정
+                if (dto.getStartDate() != null && dto.getEndDate() != null) {
+                    boolean isActive = !today.isBefore(dto.getStartDate()) && !today.isAfter(dto.getEndDate());
+                    dto.setActive(isActive); // ← 여기가 핵심
+                }
+
+                tournaments.add(dto);
             }
 
-            return tournaments.stream().filter(tournament ->
-                tournament.getStartDate().getYear() == currentYear
-            ).toList();
+            return tournaments;
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse data", e);


### PR DESCRIPTION
- Swagger 문서에서 LOL 관련 API에 [LOL] 태그를 공통으로 부여 
- Swagger UI 내 API 그룹화로 검색 및 탐색 효율 개선

2. [Feat] 토너먼트 진행중 여부(active) 필드 추가 및 LOL 응답 데이터 파싱 개선 
- Tournament DTO에 active(boolean) 필드 추가
- LOL Esports API 응답 데이터 파싱 시, 현재 날짜와 비교하여 진행 여부(active) 판단 
- 진행 중인 토너먼트 표시를 프론트엔드에서 바로 사용할 수 있도록 지원