### PR TITLE
[Refactor] 테이블 컬럼 변경에 따라 팀 즐겨찾기 관련 기능 수정

### DIFF
--- a/src/main/java/com/test/basic/lol/teams/TeamRepository.java
+++ b/src/main/java/com/test/basic/lol/teams/TeamRepository.java
@@ -25,6 +25,9 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     Optional<Team> findByCodeAndName(String code, String name);
 
+    @Query("SELECT t FROM Team t WHERE t.teamId = :teamId")
+    Optional<Team> findByTeam_TeamId(String teamId);
+
 
     //
 //    findByTeamName(String name)

--- a/src/main/java/com/test/basic/lol/teams/favorites/FavoriteTeamController.java
+++ b/src/main/java/com/test/basic/lol/teams/favorites/FavoriteTeamController.java
@@ -25,7 +25,7 @@ public class FavoriteTeamController {
         Long userId = Long.valueOf(jwt.getClaim("sub"));
 
         try {
-            favoriteTeamService.addFavoriteTeam(userId, Long.parseLong(teamId));
+            favoriteTeamService.addFavoriteTeam(userId, teamId);
             return ResponseEntity.status(HttpStatus.CREATED).build();
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("즐겨찾는 팀 등록 실패: " + e.getMessage());
@@ -45,7 +45,7 @@ public class FavoriteTeamController {
     public ResponseEntity<Void> removeFavorite(@PathVariable String teamId,
                                                @AuthenticationPrincipal Jwt jwt) {
         Long userId = Long.valueOf(jwt.getSubject());
-        favoriteTeamService.removeFavoriteTeam(userId, Long.parseLong(teamId));
+        favoriteTeamService.removeFavoriteTeam(userId, teamId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/test/basic/lol/teams/favorites/FavoriteTeamService.java
+++ b/src/main/java/com/test/basic/lol/teams/favorites/FavoriteTeamService.java
@@ -20,12 +20,12 @@ public class FavoriteTeamService {
     private final TeamRepository teamRepository;
 
     @Transactional
-    public void addFavoriteTeam(Long userId, Long teamId) {
-        if (repository.findByUserIdAndTeamId(userId, teamId).isPresent()) {
+    public void addFavoriteTeam(Long userId, String teamId) {
+        if (repository.findByUserIdAndTeam_TeamId(userId, teamId).isPresent()) {
             throw new IllegalStateException("이미 즐겨찾기에 추가된 팀입니다.");
         }
 
-        Optional<Team> team = teamRepository.findById(teamId);
+        Optional<Team> team = teamRepository.findByTeam_TeamId(teamId);
         if (! team.isPresent()) {
             throw new EntityNotFoundException("존재하지 않는 팀입니다.");
         }
@@ -41,8 +41,8 @@ public class FavoriteTeamService {
     }
 
     @Transactional
-    public void removeFavoriteTeam(Long userId, Long teamId) {
-        repository.deleteByUserIdAndTeamId(userId, teamId);
+    public void removeFavoriteTeam(Long userId, String teamId) {
+        repository.deleteByUserIdAndTeam_TeamId(userId, teamId);
     }
 
     @Transactional

--- a/src/main/java/com/test/basic/lol/teams/favorites/UserFavoriteTeamRepository.java
+++ b/src/main/java/com/test/basic/lol/teams/favorites/UserFavoriteTeamRepository.java
@@ -11,9 +11,9 @@ public interface UserFavoriteTeamRepository extends JpaRepository<UserFavoriteTe
 
     List<UserFavoriteTeam> findByUserIdOrderByDisplayOrderDesc(Long userId);
 
-    Optional<UserFavoriteTeam> findByUserIdAndTeamId(Long userId, Long teamId);
+    Optional<UserFavoriteTeam> findByUserIdAndTeam_TeamId(Long userId, String teamId);
 
-    void deleteByUserIdAndTeamId(Long userId, Long teamId);
+    void deleteByUserIdAndTeam_TeamId(Long userId, String teamId);
 
     @Query("SELECT f FROM UserFavoriteTeam f JOIN FETCH f.team WHERE f.userId = :userId ORDER BY f.displayOrder DESC")
     List<UserFavoriteTeam> findByUserIdWithTeam(@Param("userId") Long userId);


### PR DESCRIPTION
- teamId 컬럼 타입 수정
- teamId 와 Id 매핑 혼동 방지를 위해 메서드 명에 엔티티 명칭 명시