### PR TITLE
[Refactor] 경기 일정 동기화 방식을 논블로킹 → 블로킹 방식으로 변경 등

### DIFF
--- a/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
+++ b/src/main/java/com/test/basic/lol/api/LolEsportsApiClient.java
@@ -101,25 +101,34 @@ public class LolEsportsApiClient {
                 .bodyToMono(String.class);
     }
 
-    public Mono<String> fetchScheduleByLeagueIdAndPageToken(String leagueId, String finalToken) {
-
-        Mono<String> response = webClient.get()
+    public Mono<MatchScheduleResponse> fetchScheduleByLeagueIdAndPageToken(String leagueId, String finalToken) {
+        return webClient.get()
                 .uri(uriBuilder -> {
                     uriBuilder.path("/persisted/gw/getSchedule");
                     uriBuilder.queryParam("hl", HL);
                     uriBuilder.queryParam("leagueId", leagueId);
-                    if (finalToken != null) {
-                        uriBuilder.queryParam("pageToken", finalToken);
-                    }
+                    uriBuilder.queryParam("pageToken", finalToken);
+                    return uriBuilder.build();
+                })
+                .header("x-api-key", API_KEY)
+                .retrieve()
+                .bodyToMono(MatchScheduleResponse.class);
+    }
+
+    /*public Mono<String> fetchScheduleJsonByLeagueIdAndPageToken(String leagueId, String finalToken) {
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path("/persisted/gw/getSchedule");
+                    uriBuilder.queryParam("hl", HL);
+                    uriBuilder.queryParam("leagueId", leagueId);
+                    uriBuilder.queryParam("pageToken", finalToken);
                     return uriBuilder.build();
                 })
                 .header("x-api-key", API_KEY)
                 .retrieve()
                 .bodyToMono(String.class);
-
-        return response;
     }
-
+*/
 
     public Mono<String> fetchAllTeams() {
         return webClient.get()

--- a/src/main/java/com/test/basic/lol/matches/MatchController.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -17,13 +16,13 @@ import java.util.List;
 @Tag(name = "[LOL] Match API", description = "경기 일정 API")
 public class MatchController {
     private final MatchService matchService;
-    private final SyncLolEsportsApiService syncLolEsportsApiService;
+//    private final SyncLolEsportsApiService syncLolEsportsApiService;
 
     // TODO 연도 -> 날짜 검색
     @GetMapping
     public ResponseEntity<List<MatchDto>> getMatches(@RequestParam(required = false) String year,
                                                      @RequestParam(required = false) String leagueId) {
-        List<MatchDto> matches = matchService.getMatches(year, leagueId);
+        List<MatchDto> matches = matchService.getMatchesFromDB(year, leagueId);
         return ResponseEntity.ok(matches);
     }
 
@@ -34,9 +33,28 @@ public class MatchController {
         return ResponseEntity.ok(matches);
     }
 
-    // TODO 전체 리그 데이터 동기화
+    //  TODO 금일 경기가 있는 리그 데이터 30분 ~ 1시간 간격으로 동기화
     @GetMapping("/sync")
-    public Mono<ResponseEntity<List<MatchDto>>> getAllMatchesByLeagueIdFromApi() {
+    @Operation(summary = "리그별 경기일정 동기화", description = "리그별 경기일정 동기화 API")
+    public ResponseEntity syncAllMatchesByLeagueIdFromApi(@RequestParam(required = false) String year) {
+        // LCK, LCK CL, FIRST STAND, MSI, WORLDS, LPL
+        List<String> leagueIds = List.of(
+                "98767991310872058",
+                "98767991335774713",
+                "113464388705111224",
+                "98767991325878492",
+                "98767975604431411",
+                "98767991314006698");
+
+        matchService.syncMatchesByExternalApi(leagueIds, year);
+
+        return ResponseEntity.ok("리그별 경기 일정 동기화 완료");
+
+    }
+
+    // 해당 API는 단일 페이지 데이터만 동기화함
+    /*@GetMapping("/sync")
+    public Mono<ResponseEntity<List<MatchDto>>> syncAllMatchesByLeagueIdFromApi() {
         // LCK, LCK CL, FIRST STAND, MSI, WORLDS
         List<String> leagueIds = List.of(
                 "98767991310872058",
@@ -51,6 +69,6 @@ public class MatchController {
                         return ResponseEntity.ok(matches);
                     })
                 );
-    }
+    }*/
 
 }

--- a/src/main/java/com/test/basic/lol/matches/MatchService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchService.java
@@ -3,18 +3,29 @@ package com.test.basic.lol.matches;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.test.basic.lol.api.LolEsportsApiClient;
+import com.test.basic.lol.leagues.League;
+import com.test.basic.lol.leagues.LeagueRepository;
+import com.test.basic.lol.matchteams.MatchTeam;
 import com.test.basic.lol.matchteams.MatchTeamDto;
+import com.test.basic.lol.matchteams.MatchTeamRepository;
+import com.test.basic.lol.teams.Team;
 import com.test.basic.lol.teams.TeamDto;
+import com.test.basic.lol.teams.TeamRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -24,6 +35,10 @@ public class MatchService {
     private final LolEsportsApiClient apiClient;
     private final MatchMapper matchMapper;
     private final ObjectMapper objectMapper;
+    private final MatchRepository matchRepository;
+    private final TeamRepository teamRepository;
+    private final MatchTeamRepository matchTeamRepository;
+    private final LeagueRepository leagueRepository;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -32,10 +47,14 @@ public class MatchService {
     private Instant lastFetchedTime = null;
     private static final Duration TTL = Duration.ofMinutes(10);
 
-    public MatchService(LolEsportsApiClient apiClient, MatchMapper matchMapper, ObjectMapper objectMapper) {
+    public MatchService(LolEsportsApiClient apiClient, MatchMapper matchMapper, ObjectMapper objectMapper, MatchRepository matchRepository, TeamRepository teamRepository, MatchTeamRepository matchTeamRepository, LeagueRepository leagueRepository) {
         this.apiClient = apiClient;
         this.matchMapper = matchMapper;
         this.objectMapper = objectMapper;
+        this.matchRepository = matchRepository;
+        this.teamRepository = teamRepository;
+        this.matchTeamRepository = matchTeamRepository;
+        this.leagueRepository = leagueRepository;
     }
 
     public List<MatchDto> getAllMatches() {
@@ -73,7 +92,94 @@ public class MatchService {
                 .collect(Collectors.toList());
     }
 
-    public List<MatchDto> getMatchesByLeagueIdAndYear(String leagueId, String year) {
+    // 리그id, 연도별 데이터 동기화 (블로킹 방식)
+    public void syncMatchesByExternalApi(List<String> leagueIds, String year) {
+        leagueIds.forEach(
+                leagueId -> syncMatchesByLeagueIdAndYearExternalApi(leagueId, year)
+        );
+    }
+
+    public void syncMatchesByLeagueIdAndYearExternalApi(String leagueId, String year) {
+        Optional<League> leagueOpt = leagueRepository.findByLeagueId(leagueId);
+
+        // 리그가 없다면 에러 반환
+        if (leagueOpt.isEmpty()) {
+            throw new RuntimeException("League not found with id: " + leagueId);
+        }
+
+        String nextPageToken = null;
+
+        do {
+            String finalToken = nextPageToken;
+
+            MatchScheduleResponse response = apiClient
+                    .fetchScheduleByLeagueIdAndPageToken(leagueId, finalToken)
+                    .block(); // blocking call
+
+            if (response == null || response.getData() == null || response.getData().getSchedule() == null) {
+                break;
+            }
+
+            List<MatchScheduleResponse.EventDto> events = response.getData()
+                    .getSchedule()
+                    .getEvents();
+
+            boolean allBeforeTargetYear = true;
+
+            for (MatchScheduleResponse.EventDto event : events) {
+                if (event.getMatch() == null) continue;
+
+                String startTime = event.getStartTime();
+                if (startTime != null && startTime.startsWith(year)) {
+                    allBeforeTargetYear = false;
+
+                    MatchScheduleResponse.MatchDto matchDto = event.getMatch();
+
+                    // [1] Match 저장
+                    Match match = matchRepository.findByMatchId(matchDto.getId()).orElseGet(Match::new);
+                    match.setMatchId(matchDto.getId());
+                    match.setLeague(leagueOpt.get());
+                    match.setStartTime(OffsetDateTime.parse(startTime)
+                            .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                            .toLocalDateTime());
+                    match.setState(event.getState());
+                    match.setBlockName(event.getBlockName());
+                    match.setGameCount(matchDto.getStrategy().getCount());
+                    match.setStrategy(matchDto.getStrategy().getType() + matchDto.getStrategy().getCount());
+
+                    Match savedMatch = matchRepository.save(match);
+
+                    // [2] MatchTeam 저장
+                    for (MatchScheduleResponse.TeamDto teamDto : matchDto.getTeams()) {
+                        Optional<Team> teamOpt = teamRepository.findByCodeAndName(teamDto.getCode(), teamDto.getName());
+                        if (teamOpt.isEmpty()) continue;
+
+                        Team team = teamOpt.get();
+                        MatchTeam matchTeam = matchTeamRepository
+                                .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
+                                .orElseGet(MatchTeam::new);
+
+                        matchTeam.setMatch(savedMatch);
+                        matchTeam.setTeam(team);
+                        matchTeam.setOutcome(teamDto.getResult().getOutcome());
+                        matchTeam.setGameWins(teamDto.getResult().getGameWins());
+
+                        matchTeamRepository.save(matchTeam);
+                    }
+                }
+            }
+
+            // 더 이상 해당 연도의 데이터가 없으면 중단
+            if (allBeforeTargetYear) break;
+
+            nextPageToken = response.getData().getSchedule().getPages().getOlder();
+
+        } while (nextPageToken != null);
+    }
+
+
+    // 리그id, 연도별 데이터 동기화
+    /*public List<MatchDto> getMatchesByLeagueIdAndYearFromExternalApi(String leagueId, String year) {
 
         List<MatchDto> allMatches = new ArrayList<>();
         String nextPageToken = null;
@@ -81,7 +187,7 @@ public class MatchService {
         do {
             String finalToken = nextPageToken;
 
-            Mono<String> response = apiClient.fetchScheduleByLeagueIdAndPageToken(leagueId, finalToken);
+            Mono<String> response = apiClient.fetchScheduleJsonByLeagueIdAndPageToken(leagueId, finalToken);
 
             try {
                 JsonNode root = objectMapper.readTree(response.block());
@@ -92,9 +198,8 @@ public class MatchService {
                 allMatches.addAll(pageMatches);
 
                 // 중단 조건: 더 이상 해당 연도의 이벤트가 없음
-                String finalYear = year;
                 boolean allBeforeTargetYear = StreamSupport.stream(events.spliterator(), false)
-                        .allMatch(event -> !event.path("startTime").asText().startsWith(finalYear));
+                        .noneMatch(event -> event.path("startTime").asText().startsWith(year));
                 if (allBeforeTargetYear) break;
 
                 JsonNode pages = schedule.path("pages");
@@ -104,12 +209,10 @@ public class MatchService {
                 throw new RuntimeException("Failed to parse response", e);
             }
 
-            if (response == null) break;
-
         } while (nextPageToken != null);
 
         return allMatches;
-    }
+    }*/
 
     public List<MatchDto> parseMatchesFromResponse(String response, String leagueId) {
         List<MatchDto> result = new ArrayList<>();
@@ -200,7 +303,7 @@ public class MatchService {
     }
 
     // TODO 양방향 연관관계로 인한 순환참조 이슈 해결 방법 더 알아보기
-    public List<MatchDto> getMatches(String year, String leagueId) {
+    public List<MatchDto> getMatchesFromDB(String year, String leagueId) {
         StringBuilder jpql = new StringBuilder("SELECT m FROM Match m WHERE 1 = 1");
 
         if (year != null) {

--- a/src/main/java/com/test/basic/lol/sync/SyncLolEsportsApiService.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncLolEsportsApiService.java
@@ -89,7 +89,9 @@ public class SyncLolEsportsApiService {
         }
     }
 
-    public Mono<Void> syncMatchesByLeagueIds(List<String> leagueIds) {
+
+
+    /*public Mono<Void> syncMatchesByLeagueIds(List<String> leagueIds) {
         // 여러 개의 leagueId를 처리하는 Flux 생성
         return Flux.fromIterable(leagueIds)
                 // 각 leagueId에 대해 syncMatchesByLeagueId 메서드를 비동기적으로 호출
@@ -144,23 +146,23 @@ public class SyncLolEsportsApiService {
                                             List<Mono<Void>> saveTeamMonos = matchDto.getTeams().stream()
                                                     .map(teamDto -> Mono.fromCallable(() ->
                                                                     teamRepository.findByCodeAndName(teamDto.getCode(), teamDto.getName()))
-                                                            .filter(Optional::isPresent)  // 팀이 있으면
-                                                            .map(Optional::get)
-                                                            .flatMap(team -> Mono.fromCallable(() -> {
-                                                                // MatchTeam 객체 생성 및 저장
+                                                        .filter(Optional::isPresent)  // 팀이 있으면
+                                                        .map(Optional::get)
+                                                        .flatMap(team -> Mono.fromCallable(() -> {
+                                                            // MatchTeam 객체 생성 및 저장
 
-                                                                Optional<MatchTeam> matchTeamOpt = matchTeamRepository
-                                                                        .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId());
-                                                                MatchTeam mTeam = matchTeamOpt.orElseGet(MatchTeam::new);
+                                                            Optional<MatchTeam> matchTeamOpt = matchTeamRepository
+                                                                    .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId());
+                                                            MatchTeam mTeam = matchTeamOpt.orElseGet(MatchTeam::new);
 
-                                                                mTeam.setMatch(savedMatch);
-                                                                mTeam.setTeam(team);
-                                                                mTeam.setOutcome(teamDto.getResult().getOutcome());
-                                                                mTeam.setGameWins(teamDto.getResult().getGameWins());
-                                                                matchTeamRepository.save(mTeam); // 저장
+                                                            mTeam.setMatch(savedMatch);
+                                                            mTeam.setTeam(team);
+                                                            mTeam.setOutcome(teamDto.getResult().getOutcome());
+                                                            mTeam.setGameWins(teamDto.getResult().getGameWins());
+                                                            matchTeamRepository.save(mTeam); // 저장
 
-                                                                return (Void) null;
-                                                            }))
+                                                            return (Void) null;
+                                                        }))
                                                     )
                                                     .toList(); // 모든 팀 저장 작업을 리스트로 모음
 
@@ -170,6 +172,6 @@ public class SyncLolEsportsApiService {
                             })
                             .then(); // 모든 이벤트 처리 후 완료
                 });
-    }
+    }*/
 
 }


### PR DESCRIPTION
- WebClient 호출 결과 block()으로 처리

[Feat] 경기 일정 동기화 시 외부 API 응답 파싱용 ResponseDto 도입
- 경기 일정 동기화 응답 구조에 맞춘 ResponseDto 생성

[Fix] 연도별 일정 동기화 시 날짜 기준 필터링 로직 추가
- startTime 기준으로 해당 연도 데이터만 수집하도록 개선