### PR TITLE
[Fix] 경기일정 갱신 로직이 장시간 경기 누락하는 문제 수정

### DIFF
--- a/src/main/java/com/test/basic/lol/sync/SyncLolEsportsSchedulerDev.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncLolEsportsSchedulerDev.java
@@ -61,22 +61,8 @@ public class SyncLolEsportsSchedulerDev {
             return;
         }
 
-        // 현재 시각 기준으로 1시간 전후 경기만 갱신 대상으로 선정
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime oneHourAgo = now.minusHours(2);
-        LocalDateTime oneHourLater = now.plusHours(1);
-        List<Match> matches = todayMatches.stream()
-                .filter(m -> m.getStartTime().isAfter(oneHourAgo) && m.getStartTime().isBefore(oneHourLater))
-                .toList();
-
-        if (matches.isEmpty()) {
-            logger.info(">>> 동기화 작업을 건너뜁니다.");
-            logger.info("==================== [금일 경기 정보 자동 동기화 작업 종료] ====================");
-            return;
-        }
-
-        logger.info(">>> 동기화 대상 경기 수: {}", matches.size());
-        syncMatchService.syncTodaysMatchesFromLolEsportsApi(matches);
+        logger.info(">>> 동기화 대상 경기 수: {}", todayMatches.size());
+        syncMatchService.syncTodaysMatchesFromLolEsportsApi(todayMatches);
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 완료] ====================");
     }
 

--- a/src/main/java/com/test/basic/lol/sync/SyncLolEsportsSchedulerProd.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncLolEsportsSchedulerProd.java
@@ -56,22 +56,8 @@ public class SyncLolEsportsSchedulerProd {
             return;
         }
 
-        // 현재 시각 기준으로 1시간 전후 경기만 갱신 대상으로 선정
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime oneHourAgo = now.minusHours(2);
-        LocalDateTime oneHourLater = now.plusHours(1);
-        List<Match> matches = todayMatches.stream()
-                .filter(m -> m.getStartTime().isAfter(oneHourAgo) && m.getStartTime().isBefore(oneHourLater))
-                .toList();
-
-        if (matches.isEmpty()) {
-            logger.info(">>> 동기화 작업을 건너뜁니다.");
-            logger.info("==================== [금일 경기 정보 자동 동기화 작업 종료] ====================");
-            return;
-        }
-
-        logger.info(">>> 동기화 대상 경기 수: {}", matches.size());
-        syncMatchService.syncTodaysMatchesFromLolEsportsApi(matches);
+        logger.info(">>> 동기화 대상 경기 수: {}", todayMatches.size());
+        syncMatchService.syncTodaysMatchesFromLolEsportsApi(todayMatches);
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 완료] ====================");
     }
 

--- a/src/main/java/com/test/basic/lol/sync/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncMatchService.java
@@ -33,8 +33,7 @@ public class SyncMatchService {
     private final TeamRepository teamRepository;
     private final MatchTeamRepository matchTeamRepository;
 
-    // TODO 
-    //  - 경기 시간과 현재시각 비교해서 시작 1시간쯤 전부터만 갱신하기
+
     @Transactional
     public String syncTodaysMatchesFromLolEsportsApi(List<Match> matches) {
         // Redisson Lock 획득


### PR DESCRIPTION
- 기존: 경기 시작 시간이 현재 시각 기준 ±1시간인 경우만 갱신 대상으로 포함
- 문제: 경기 진행 시간이 길어질 경우 갱신 대상에서 누락됨
- 해결: 첫 경기 시작 시간부터 금일 경기 데이터 모두 갱신 대상에 포함하도록 수정