### PR TITLE
[Fix] Logback 설정 최신화 및 @PreDestroy 메서드 인자 제거

### DIFF
--- a/src/main/java/com/test/basic/lol/sync/SyncTeamService.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncTeamService.java
@@ -108,7 +108,7 @@ public class SyncTeamService {
             logger.error(">>> 락 획득 중 예외 발생: {}", e.getMessage());
             return "락 획득 실패";
         } finally {
-            cleanup(isLocked);
+            cleanup();
         }
     }
 
@@ -134,8 +134,8 @@ public class SyncTeamService {
 
     // 애플리케이션이 종료되거나 컨테이너가 닫히기 전에 자원 정리
     @PreDestroy
-    private void cleanup(boolean isLocked) {
-        if (isLocked && lock.isHeldByCurrentThread()) {
+    private void cleanup() {
+        if (lock != null && lock.isHeldByCurrentThread()) {
             lock.unlock();
             logger.warn(">>> 락 해제 완료");
         } else {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,14 +19,11 @@
     <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/${APP_NAME}-info.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- 하루 단위 롤링 + 압축 -->
             <fileNamePattern>${LOG_PATH}/${APP_NAME}-info.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <!-- 용량 2MB 넘으면 롤링 -->
-                <maxFileSize>2MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>7</maxHistory> <!-- 최대 7일치 보관 -->
+            <maxFileSize>2MB</maxFileSize>  <!-- 용량 2MB 넘으면 롤링 -->
+            <maxHistory>7</maxHistory>      <!-- 최대 7일치 보관 -->
         </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>


### PR DESCRIPTION
- Logback 구버전 설정인 SizeAndTimeBasedFNATP 제거
- @PreDestroy 메서드에서 라이프사이클 어노테이션 규칙에 따라 인자 제거