### PR TITLE
[Feat] 경기 일정 조회 시 Redis 캐싱 및 채팅 Redis 구조 개선

### DIFF
--- a/src/main/java/com/test/basic/common/config/RedisConfig.java
+++ b/src/main/java/com/test/basic/common/config/RedisConfig.java
@@ -1,6 +1,11 @@
 package com.test.basic.common.config;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.test.basic.chat.RedisMessageListener;
+import com.test.basic.lol.matches.MatchDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -9,6 +14,10 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
 
 @Configuration
 public class RedisConfig {
@@ -21,6 +30,8 @@ public class RedisConfig {
         this.redisMessageListener = redisMessageListener;
     }
 
+    // [1] 채팅용 ==================================================================
+    // [1-1] 채팅 메시지 문자열 저장용 레디스 템플릿 등록
     @Bean
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
@@ -28,19 +39,53 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    // Redis Pub/Sub 메시지를 처리하는 리스너를 등록
+    // 채팅, 알림, 실시간 이벤트 같은 "메시지 브로드캐스트"에만 사용
     @Bean
-//    public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory) {
     public RedisMessageListenerContainer redisContainer() {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-//        container.setConnectionFactory(connectionFactory);
         container.setConnectionFactory(redisTemplate.getConnectionFactory());
 
-        // 특정 채널 구독(Subscribe)
+        // 특정 채널(topic) 구독(Subscribe)
         // chat:room:1 으로 들어온 모든 메시지를 redisMessageListener로 전달
-        // 채팅방마다 다른 채널 사용 -> 리소스 사용량 증가
         container.addMessageListener(new MessageListenerAdapter(redisMessageListener),
-                new ChannelTopic("chat:room:1"));
+                topic());
+
+        // Ex) 채팅방마다 다른 채널 사용 -> 리소스 사용량 증가
+        // new ChannelTopic("chat:room:1")
+        // new ChannelTopic("chat:room:2")
+        // new ChannelTopic("chat:room:3")
+
         return container;
+    }
+
+    @Bean
+    public ChannelTopic topic() {
+        // 채팅방 구분 없이 모든 메시지가 "chat:room:1" 하나의 채널에서 관리됨
+        // -> 리소스 절약 (대규모 시스템에 적합)
+        return new ChannelTopic("chat:room:1");
+    }
+
+
+    // [2] 롤 경기일정용 ==================================================================
+    // [2-1] MatchDto 직렬화용 RedisTemplate 등록
+    // - pub/sub를 사용하지 않고 get/set과 같은 단순 데이터 저장/조회만 하면 되므로 리스너 등록 불필요
+    @Bean
+    public RedisTemplate<String, List<MatchDto>> matchRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, List<MatchDto>> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 직렬화 대상 데이터 타입 명시
+        JavaType type = objectMapper.getTypeFactory().constructCollectionType(List.class, MatchDto.class);
+        Jackson2JsonRedisSerializer<List<MatchDto>> serializer = new Jackson2JsonRedisSerializer<>(type);
+
+        template.setValueSerializer(serializer);
+        return template;
     }
 
 

--- a/src/main/java/com/test/basic/lol/matches/MatchService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchService.java
@@ -13,8 +13,11 @@ import com.test.basic.lol.teams.TeamDto;
 import com.test.basic.lol.teams.TeamRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.TypedQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
 
 import java.time.*;
 import java.util.ArrayList;
@@ -26,6 +29,8 @@ import java.util.stream.StreamSupport;
 
 @Service
 public class MatchService {
+    private static final Logger logger = LoggerFactory.getLogger(MatchService.class);
+
     private final LolEsportsApiClient apiClient;
     private final MatchMapper matchMapper;
     private final ObjectMapper objectMapper;
@@ -33,6 +38,7 @@ public class MatchService {
     private final TeamRepository teamRepository;
     private final MatchTeamRepository matchTeamRepository;
     private final LeagueRepository leagueRepository;
+    private final RedisTemplate<String, List<MatchDto>> matchRedisTemplate;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -41,7 +47,7 @@ public class MatchService {
     private Instant lastFetchedTime = null;
     private static final Duration TTL = Duration.ofMinutes(10);
 
-    public MatchService(LolEsportsApiClient apiClient, MatchMapper matchMapper, ObjectMapper objectMapper, MatchRepository matchRepository, TeamRepository teamRepository, MatchTeamRepository matchTeamRepository, LeagueRepository leagueRepository) {
+    public MatchService(LolEsportsApiClient apiClient, MatchMapper matchMapper, ObjectMapper objectMapper, MatchRepository matchRepository, TeamRepository teamRepository, MatchTeamRepository matchTeamRepository, LeagueRepository leagueRepository, RedisTemplate<String, List<MatchDto>> matchRedisTemplate) {
         this.apiClient = apiClient;
         this.matchMapper = matchMapper;
         this.objectMapper = objectMapper;
@@ -49,6 +55,7 @@ public class MatchService {
         this.teamRepository = teamRepository;
         this.matchTeamRepository = matchTeamRepository;
         this.leagueRepository = leagueRepository;
+        this.matchRedisTemplate = matchRedisTemplate;
     }
 
     public List<MatchDto> getAllMatches() {
@@ -187,43 +194,6 @@ public class MatchService {
         } while (nextPageToken != null);
     }
 
-
-    // 리그id, 연도별 데이터 동기화
-    /*public List<MatchDto> getMatchesByLeagueIdAndYearFromExternalApi(String leagueId, String year) {
-
-        List<MatchDto> allMatches = new ArrayList<>();
-        String nextPageToken = null;
-
-        do {
-            String finalToken = nextPageToken;
-
-            Mono<String> response = apiClient.fetchScheduleJsonByLeagueIdAndPageToken(leagueId, finalToken);
-
-            try {
-                JsonNode root = objectMapper.readTree(response.block());
-                JsonNode schedule = root.path("data").path("schedule");
-                JsonNode events = schedule.path("events");
-
-                List<MatchDto> pageMatches = parseMatchesFromEvents(events, leagueId, year);
-                allMatches.addAll(pageMatches);
-
-                // 중단 조건: 더 이상 해당 연도의 이벤트가 없음
-                boolean allBeforeTargetYear = StreamSupport.stream(events.spliterator(), false)
-                        .noneMatch(event -> event.path("startTime").asText().startsWith(year));
-                if (allBeforeTargetYear) break;
-
-                JsonNode pages = schedule.path("pages");
-                nextPageToken = pages.path("older").asText(null);
-
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to parse response", e);
-            }
-
-        } while (nextPageToken != null);
-
-        return allMatches;
-    }*/
-
     public List<MatchDto> parseMatchesFromResponse(String response, String leagueId) {
         List<MatchDto> result = new ArrayList<>();
 
@@ -271,7 +241,140 @@ public class MatchService {
         return result;
     }
 
-    public List<MatchDto> parseMatchesFromEvents(JsonNode events, String leagueId, String year) {
+    public List<Match> getMatchesByDate(LocalDateTime startOfDay, LocalDateTime endOfDay) {
+        return matchRepository.findMatchesByDate(startOfDay, endOfDay);
+    }
+
+    public Optional<LocalDateTime> getFirstMatchTimeOfDay(LocalDateTime startOfDay, LocalDateTime endOfDay) {
+        return matchRepository.findFirstMatchTimeOfDay(startOfDay, endOfDay);
+    }
+
+    public List<MatchDto> getMatchesByLeagueIdAndDate(String leagueId, LocalDate startDate, LocalDate endDate) {
+        logger.info("==================== [경기 일정 조회 시작] ====================");
+
+        StopWatch sw = new StopWatch();
+        sw.start();
+
+        List<MatchDto> result = new ArrayList<>();
+
+        String redisKey = String.join(":", "match", leagueId, startDate.toString(), endDate.toString());
+
+        List<MatchDto> cachedMatches = getMatchList(redisKey);
+
+        if (cachedMatches != null) {
+            logger.info(">>> Redis 캐시 Hit: {}", redisKey);
+            result.addAll(cachedMatches);
+        } else {
+            // 캐시 없을 경우 DB 조회 + 캐시 저장 로직
+            logger.info(">>> Redis 캐시 Miss. DB 조회 시작: {}", redisKey);
+            
+            LocalDateTime startOfDay = startDate.atStartOfDay();
+            LocalDateTime endOfDay;
+
+            if (startDate.equals(endDate)) {
+                // 하루만 조회할 경우: 해당 날짜의 끝까지
+                endOfDay = startDate.plusDays(1).atStartOfDay().minusNanos(1);
+            } else {
+                // 여러 날 조회할 경우: endDate의 끝까지 포함
+                endOfDay = endDate.plusDays(1).atStartOfDay().minusNanos(1);
+            }
+
+            List<Match> matches = matchRepository.findMatchByLeagueIdAndDate(leagueId, startOfDay, endOfDay);
+            result = matches.stream().map(matchMapper::entityToDto).toList();
+
+            // 캐시 저장
+            cacheMatchList(redisKey, result);
+        }
+
+        sw.stop();
+        logger.info(">>> 소요 시간: {}ms", sw.getTotalTimeMillis());
+        logger.info("==================== [경기 일정 조회 완료] ====================");
+        
+        return result;
+    }
+
+    // 캐싱 (연도별 리그 데이터 조회에서 사용 후 조회 소요 시간 1~2초 이상 -> 100ms 미만)
+    // key: "match:leagueId:startDate:endDate" 로 저장
+    public void cacheMatchList(String key, List<MatchDto> matches) {
+        matchRedisTemplate.opsForValue().set(key, matches, Duration.ofMinutes(10));
+        logger.info(">>> Cached matches for key: {}", key);
+    }
+
+    public List<MatchDto> getMatchList(String key) {
+        return matchRedisTemplate.opsForValue().get(key);
+    }
+
+
+    // TODO 삭제 ----------------------------------------------------------------------------
+
+    // 양방향 연관관계로 인한 순환참조 이슈 해결 방법 더 알아보기
+    //  -> findMatchByLeagueIdAndDate 메서드 사용으로 변경
+    /*public List<MatchDto> getMatchesFromDB(String year, String leagueId) {
+        StringBuilder jpql = new StringBuilder("SELECT m FROM Match m WHERE 1 = 1");
+
+        if (year != null) {
+            jpql.append(" AND FUNCTION('date_part', 'year', m.startTime) = :year");
+        }
+        if (leagueId != null) {
+            jpql.append(" AND m.league.leagueId = :leagueId");
+        }
+
+        // JPQL 쿼리 생성
+        TypedQuery<Match> query = entityManager.createQuery(jpql.toString(), Match.class);
+
+        // 파라미터 설정
+        if (year != null) {
+            query.setParameter("year", Integer.parseInt(year)); // YEAR 함수는 정수로 비교
+        }
+        if (leagueId != null) {
+            query.setParameter("leagueId", leagueId);
+        }
+
+        // 결과 반환
+        List<Match> matches = query.getResultList();
+
+        return matches.stream()
+                .map(matchMapper::entityToDto)
+                .toList();
+    }*/
+
+    // 리그id, 연도별 데이터 동기화
+    /*public List<MatchDto> getMatchesByLeagueIdAndYearFromExternalApi(String leagueId, String year) {
+
+        List<MatchDto> allMatches = new ArrayList<>();
+        String nextPageToken = null;
+
+        do {
+            String finalToken = nextPageToken;
+
+            Mono<String> response = apiClient.fetchScheduleJsonByLeagueIdAndPageToken(leagueId, finalToken);
+
+            try {
+                JsonNode root = objectMapper.readTree(response.block());
+                JsonNode schedule = root.path("data").path("schedule");
+                JsonNode events = schedule.path("events");
+
+                List<MatchDto> pageMatches = parseMatchesFromEvents(events, leagueId, year);
+                allMatches.addAll(pageMatches);
+
+                // 중단 조건: 더 이상 해당 연도의 이벤트가 없음
+                boolean allBeforeTargetYear = StreamSupport.stream(events.spliterator(), false)
+                        .noneMatch(event -> event.path("startTime").asText().startsWith(year));
+                if (allBeforeTargetYear) break;
+
+                JsonNode pages = schedule.path("pages");
+                nextPageToken = pages.path("older").asText(null);
+
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse response", e);
+            }
+
+        } while (nextPageToken != null);
+
+        return allMatches;
+    }*/
+
+    /*public List<MatchDto> parseMatchesFromEvents(JsonNode events, String leagueId, String year) {
         List<MatchDto> result = new ArrayList<>();
 
         for (JsonNode event : events) {
@@ -312,60 +415,6 @@ public class MatchService {
         }
 
         return result;
-    }
-
-    // TODO 양방향 연관관계로 인한 순환참조 이슈 해결 방법 더 알아보기
-    public List<MatchDto> getMatchesFromDB(String year, String leagueId) {
-        StringBuilder jpql = new StringBuilder("SELECT m FROM Match m WHERE 1 = 1");
-
-        if (year != null) {
-            jpql.append(" AND FUNCTION('date_part', 'year', m.startTime) = :year");
-        }
-        if (leagueId != null) {
-            jpql.append(" AND m.league.leagueId = :leagueId");
-        }
-
-        // JPQL 쿼리 생성
-        TypedQuery<Match> query = entityManager.createQuery(jpql.toString(), Match.class);
-
-        // 파라미터 설정
-        if (year != null) {
-            query.setParameter("year", Integer.parseInt(year)); // YEAR 함수는 정수로 비교
-        }
-        if (leagueId != null) {
-            query.setParameter("leagueId", leagueId);
-        }
-
-        // 결과 반환
-        List<Match> matches = query.getResultList();
-
-        return matches.stream()
-                .map(matchMapper::entityToDto)
-                .toList();
-    }
-
-    public List<Match> getMatchesByDate(LocalDateTime startOfDay, LocalDateTime endOfDay) {
-        return matchRepository.findMatchesByDate(startOfDay, endOfDay);
-    }
-
-    public Optional<LocalDateTime> getFirstMatchTimeOfDay(LocalDateTime startOfDay, LocalDateTime endOfDay) {
-        return matchRepository.findFirstMatchTimeOfDay(startOfDay, endOfDay);
-    }
-
-    public List<MatchDto> getMatchesByLeagueIdAndDate(String leagueId, LocalDate startDate, LocalDate endDate) {
-        LocalDateTime startOfDay = startDate.atStartOfDay();
-        LocalDateTime endOfDay;
-
-        if (startDate.equals(endDate)) {
-            // 하루만 조회할 경우: 해당 날짜의 끝까지
-            endOfDay = startDate.plusDays(1).atStartOfDay().minusNanos(1);
-        } else {
-            // 여러 날 조회할 경우: endDate의 끝까지 포함
-            endOfDay = endDate.plusDays(1).atStartOfDay().minusNanos(1);
-        }
-
-        List<Match> matches = matchRepository.findMatchByLeagueIdAndDate(leagueId, startOfDay, endOfDay);
-        return matches.stream().map(matchMapper::entityToDto).toList();
-    }
+    }*/
 
 }


### PR DESCRIPTION
- 경기 일정 조회 결과(MatchDto 리스트)를 Redis에 캐싱하도록 RedisTemplate 빈 추가
- MatchService 에 경기 일정 조회 소요 시간 로그 추가
- RedisConfig 내 주석 정리
- 채팅용 RedisTemplate 단일 Pub/Sub 채널(chat:room:1) 사용