### PR TITLE
[refactor] MatchService 의존성 분리 및 역할별 서비스 추출

### DIFF
--- a/src/main/java/com/test/basic/lol/matches/MatchApiService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchApiService.java
@@ -1,0 +1,92 @@
+package com.test.basic.lol.matches;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.test.basic.lol.api.LolEsportsApiClient;
+import com.test.basic.lol.api.dto.matches.MatchDetailResponse;
+import com.test.basic.lol.api.dto.matches.MatchScheduleResponse;
+import com.test.basic.lol.matchteams.MatchTeamDto;
+import com.test.basic.lol.teams.TeamDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@Service
+@RequiredArgsConstructor
+public class MatchApiService {
+    private final LolEsportsApiClient apiClient;
+    private final ObjectMapper objectMapper;
+
+
+    public List<MatchDto> fetchAllMatches() {
+        String json = apiClient.fetchScheduleMatchesJson().block();
+        return parseMatchesFromJson(json, null);
+    }
+
+    public List<MatchDto> fetchMatchesByLeague(String leagueId) {
+        String json = apiClient.fetchScheduleMatchesJson().block();
+        return parseMatchesFromJson(json, leagueId);
+    }
+
+    public List<MatchDto> parseMatchesFromJson(String response, String leagueId) {
+        List<MatchDto> result = new ArrayList<>();
+
+        try {
+            JsonNode events = objectMapper.readTree(response)
+                    .path("data").path("schedule").path("events");
+
+            for (JsonNode event : events) {
+                List<MatchTeamDto> matchTeamDtos = StreamSupport.stream(
+                                event.path("match").path("teams").spliterator(), false)
+                        .map(team -> new MatchTeamDto(
+                                team.path("result").path("outcome").asText(),
+                                team.path("result").path("gameWins").asInt(),
+                                new TeamDto(team.path("code").asText(),
+                                        team.path("name").asText())
+                        ))
+                        .toList();
+
+                boolean completed = event.path("state").asText().equalsIgnoreCase("completed");
+                String winningTeamCode = completed
+                        ? matchTeamDtos.stream()
+                        .filter(team -> "win".equalsIgnoreCase(team.getOutcome()))
+                        .map(matchTeamDto -> matchTeamDto.getTeam().getCode())
+                        .findFirst().orElse(null)
+                        : null;
+
+                result.add(new MatchDto(
+                        event.path("match").path("id").asText(),
+                        event.path("startTime").asText(),
+                        event.path("state").asText(),
+                        event.path("strategy").path("type").asText(),
+                        winningTeamCode,
+                        matchTeamDtos.stream()
+                                .map(team -> {
+                                    team.getTeam().setLeagueId(leagueId);
+                                    return team;
+                                })
+                                .toList()
+                ));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse schedule data", e);
+        }
+
+        return result;
+    }
+
+    public MatchScheduleResponse fetchScheduleByLeagueIdAndPageToken(String leagueId, String pageToken) {
+        return apiClient
+                .fetchScheduleByLeagueIdAndPageToken(leagueId, pageToken)
+                .block();
+    }
+
+    public Mono<MatchDetailResponse> fetchMatchDetailFromApi(String matchId) {
+        return apiClient.fetchMatchDetailFromApi(matchId);
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/matches/MatchCacheService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchCacheService.java
@@ -1,0 +1,57 @@
+package com.test.basic.lol.matches;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatchCacheService {
+    private static final Logger logger = LoggerFactory.getLogger(MatchCacheService.class);
+
+    private final RedisTemplate<String, List<MatchDto>> matchRedisTemplate;
+    
+    private static final Duration TTL = Duration.ofMinutes(10);
+    
+    private List<MatchDto> cachedMatches = null;
+    private Instant lastFetchedTime = null;
+
+
+
+    // Redis 캐시 ========================
+    public List<MatchDto> getCachedMatchList(String key) {
+        return matchRedisTemplate.opsForValue().get(key);
+    }
+
+    // 캐싱 (연도별 리그 데이터 조회에서 사용 후 조회 소요 시간 1~2초 이상 -> 100ms 미만)
+    // key: "match:leagueId:startDate:endDate" 로 저장
+    public void cacheMatchList(String key, List<MatchDto> matches) {
+        matchRedisTemplate.opsForValue().set(key, matches, TTL);
+        logger.info(">>> Cached matches for key: {}", key);
+    }
+
+
+    // 메모리 캐시 ========================
+    public List<MatchDto> getMemoryCachedMatches() {
+        if (cachedMatches != null && lastFetchedTime != null &&
+                Duration.between(lastFetchedTime, Instant.now()).compareTo(TTL) < 0) {
+            logger.info(">>> 메모리 캐시 Hit");
+            return cachedMatches;
+        }
+        logger.info(">>> 메모리 캐시 Miss");
+        return null;
+    }
+
+    public void setMemoryCachedMatches(List<MatchDto> matches) {
+        cachedMatches = matches;
+        lastFetchedTime = Instant.now();
+        logger.info(">>> 메모리 캐시 저장 완료");
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/matches/MatchService.java
+++ b/src/main/java/com/test/basic/lol/matches/MatchService.java
@@ -1,88 +1,60 @@
 package com.test.basic.lol.matches;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.test.basic.lol.api.LolEsportsApiClient;
-import com.test.basic.lol.api.dto.matches.MatchScheduleResponse;
-import com.test.basic.lol.leagues.League;
-import com.test.basic.lol.leagues.LeagueRepository;
-import com.test.basic.lol.matchteams.MatchTeam;
-import com.test.basic.lol.matchteams.MatchTeamDto;
-import com.test.basic.lol.matchteams.MatchTeamRepository;
-import com.test.basic.lol.teams.Team;
-import com.test.basic.lol.teams.TeamDto;
-import com.test.basic.lol.teams.TeamRepository;
+import com.test.basic.lol.sync.SyncMatchService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
 
-import java.time.*;
-import java.util.ArrayList;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 
 @Service
 public class MatchService {
     private static final Logger logger = LoggerFactory.getLogger(MatchService.class);
 
-    private final LolEsportsApiClient apiClient;
+    private final MatchApiService matchApiService;
+    private final MatchCacheService matchCacheService;
+    private final SyncMatchService syncMatchService;
     private final MatchMapper matchMapper;
-    private final ObjectMapper objectMapper;
     private final MatchRepository matchRepository;
-    private final TeamRepository teamRepository;
-    private final MatchTeamRepository matchTeamRepository;
-    private final LeagueRepository leagueRepository;
-    private final RedisTemplate<String, List<MatchDto>> matchRedisTemplate;
 
     @PersistenceContext
     private EntityManager entityManager;
 
-    private List<MatchDto> cachedMatches = null;
-    private Instant lastFetchedTime = null;
-    private static final Duration TTL = Duration.ofMinutes(10);
-
-    public MatchService(LolEsportsApiClient apiClient, MatchMapper matchMapper, ObjectMapper objectMapper, MatchRepository matchRepository, TeamRepository teamRepository, MatchTeamRepository matchTeamRepository, LeagueRepository leagueRepository, RedisTemplate<String, List<MatchDto>> matchRedisTemplate) {
-        this.apiClient = apiClient;
+    public MatchService(MatchMapper matchMapper, MatchRepository matchRepository, MatchCacheService matchCacheService, MatchApiService matchApiService, SyncMatchService syncMatchService) {
         this.matchMapper = matchMapper;
-        this.objectMapper = objectMapper;
         this.matchRepository = matchRepository;
-        this.teamRepository = teamRepository;
-        this.matchTeamRepository = matchTeamRepository;
-        this.leagueRepository = leagueRepository;
-        this.matchRedisTemplate = matchRedisTemplate;
+        this.matchCacheService = matchCacheService;
+        this.matchApiService = matchApiService;
+        this.syncMatchService = syncMatchService;
     }
 
     public List<MatchDto> getAllMatches() {
-        if (cachedMatches != null && lastFetchedTime != null &&
-                Duration.between(lastFetchedTime, Instant.now()).compareTo(TTL) < 0) {
-            return cachedMatches; // 아직 TTL 안 지났으면 캐시 데이터 사용
-        }
+        List<MatchDto> cached = matchCacheService.getMemoryCachedMatches();
+        if (cached != null) return cached;
 
         // TTL 지났거나 최초 요청이면 새로 로딩
-        String response = apiClient.fetchScheduleMatchesJson().block();
-        cachedMatches = parseMatchesFromResponse(response, null);
-        lastFetchedTime = Instant.now();
-        return cachedMatches;
+        List<MatchDto> freshMatches = matchApiService.fetchAllMatches();
+        matchCacheService.setMemoryCachedMatches(freshMatches);
+        return freshMatches;
     }
 
     public List<MatchDto> getMatchesByLeagueId(String leagueId) {
-        if (cachedMatches != null && lastFetchedTime != null &&
-                Duration.between(lastFetchedTime, Instant.now()).compareTo(TTL) < 0) {
-            return cachedMatches; // 아직 TTL 안 지났으면 캐시 데이터 사용
-        }
+        List<MatchDto> cached = matchCacheService.getMemoryCachedMatches();
+        if (cached != null) return cached;  // 아직 TTL 안 지났으면 캐시 데이터 사용
 
         // TTL 지났거나 최초 요청이면 새로 로딩
-        String response = apiClient.fetchScheduleMatchesJson().block();
-        cachedMatches = parseMatchesFromResponse(response, leagueId);
-        lastFetchedTime = Instant.now();
-        return cachedMatches;
+        List<MatchDto> freshMatches = matchApiService.fetchMatchesByLeague(leagueId);
+        matchCacheService.setMemoryCachedMatches(freshMatches);
+        return freshMatches;
     }
 
     public List<MatchDto> getMatchesByTeamName(String name) {
@@ -93,159 +65,6 @@ public class MatchService {
                                 .equalsIgnoreCase(name)))
                 .collect(Collectors.toList());
     }
-
-    // 리그id, 연도별 데이터 동기화 (블로킹 방식)
-    public void syncMatchesByExternalApi(List<String> leagueIds, String year) {
-        leagueIds.forEach(
-                leagueId -> syncMatchesByLeagueIdAndYearExternalApi(leagueId, year)
-        );
-    }
-
-    // 파라미터로 전달된 YEAR 데이터까지만 갱신.
-    // EX) 2022를 전달한 경우, 금년 2025부터~2024,2023,2022 데이터 갱신
-    public void syncMatchesByLeagueIdAndYearExternalApi(String leagueId, String year) {
-        Optional<League> leagueOpt = leagueRepository.findByLeagueId(leagueId);
-        if (leagueOpt.isEmpty()) {
-            throw new RuntimeException("League not found with id: " + leagueId);
-        }
-
-        int targetYear = Integer.parseInt(year);
-        String nextPageToken = null;
-
-        do {
-            String finalToken = nextPageToken;
-
-            MatchScheduleResponse response = apiClient
-                    .fetchScheduleByLeagueIdAndPageToken(leagueId, finalToken)
-                    .block();
-
-            if (response == null || response.getData() == null || response.getData().getSchedule() == null) {
-                break;
-            }
-
-            List<MatchScheduleResponse.EventDto> events = response.getData()
-                    .getSchedule()
-                    .getEvents();
-
-            // 1️⃣ 페이지 내 모든 이벤트가 targetYear보다 이전이면 종료
-            boolean allBeforeTargetYear = events.stream()
-                    .filter(event -> event.getStartTime() != null)
-                    .map(event -> OffsetDateTime.parse(event.getStartTime())
-                            .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
-                            .toLocalDateTime()
-                            .getYear())
-                    .allMatch(eventYear -> eventYear < targetYear);
-
-            if (allBeforeTargetYear) break;
-
-            for (MatchScheduleResponse.EventDto event : events) {
-                if (event.getMatch() == null || event.getStartTime() == null) continue;
-
-                LocalDateTime eventDateTime = OffsetDateTime.parse(event.getStartTime())
-                        .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
-                        .toLocalDateTime();
-
-                int eventYear = eventDateTime.getYear();
-
-                // 2️⃣ 연도가 타겟보다 작으면 무시 (스킵)
-                if (eventYear < targetYear) continue;
-
-                MatchScheduleResponse.MatchDto matchDto = event.getMatch();
-
-                // [1] Match 저장
-                Match match = matchRepository.findByMatchId(matchDto.getId()).orElseGet(Match::new);
-                match.setMatchId(matchDto.getId());
-                match.setLeague(leagueOpt.get());
-                match.setStartTime(eventDateTime);
-                match.setState(event.getState());
-                match.setBlockName(event.getBlockName());
-                match.setGameCount(matchDto.getStrategy().getCount());
-                match.setStrategy(matchDto.getStrategy().getType() + matchDto.getStrategy().getCount());
-
-                Match savedMatch = matchRepository.save(match);
-
-                // [2] MatchTeam 저장.
-                for (MatchScheduleResponse.TeamDto teamDto : matchDto.getTeams()) {
-                    Optional<Team> teamOpt;
-                    if (teamDto.getName().equalsIgnoreCase("TBD")) {    // TBD (To Be Determined)
-                        teamOpt = teamRepository.findByName(teamDto.getName());
-                    } else {
-                        teamOpt = teamRepository.findByCodeAndName(teamDto.getCode(), teamDto.getName());
-                    }
-
-                    if (teamOpt.isEmpty()) {
-                        throw new RuntimeException("Team not found with name: " + teamDto.getName());
-                    }
-
-                    Team team = teamOpt.get();
-                    MatchTeam matchTeam = matchTeamRepository
-                            .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
-                            .orElseGet(MatchTeam::new);
-
-                    matchTeam.setMatch(savedMatch);
-                    matchTeam.setTeam(team);
-
-                    if (teamDto.getResult() != null) {
-                        matchTeam.setOutcome(teamDto.getResult().getOutcome());
-                        matchTeam.setGameWins(teamDto.getResult().getGameWins());
-                    }
-
-                    matchTeamRepository.save(matchTeam);
-                }
-            }
-
-            nextPageToken = response.getData().getSchedule().getPages().getOlder();
-
-        } while (nextPageToken != null);
-    }
-
-    public List<MatchDto> parseMatchesFromResponse(String response, String leagueId) {
-        List<MatchDto> result = new ArrayList<>();
-
-        try {
-            JsonNode events = objectMapper.readTree(response)
-                    .path("data").path("schedule").path("events");
-
-            for (JsonNode event : events) {
-                List<MatchTeamDto> matchTeamDtos = StreamSupport.stream(
-                                event.path("match").path("teams").spliterator(), false)
-                        .map(team -> new MatchTeamDto(
-                                team.path("result").path("outcome").asText(),
-                                team.path("result").path("gameWins").asInt(),
-                                new TeamDto(team.path("code").asText(),
-                                            team.path("name").asText())
-                        ))
-                        .toList();
-
-                boolean completed = event.path("state").asText().equalsIgnoreCase("completed");
-                String winningTeamCode = completed
-                        ? matchTeamDtos.stream()
-                        .filter(team -> "win".equalsIgnoreCase(team.getOutcome()))
-                        .map(matchTeamDto -> matchTeamDto.getTeam().getCode())
-                        .findFirst().orElse(null)
-                        : null;
-
-                result.add(new MatchDto(
-                        event.path("match").path("id").asText(),
-                        event.path("startTime").asText(),
-                        event.path("state").asText(),
-                        event.path("strategy").path("type").asText(),
-                        winningTeamCode,
-                        matchTeamDtos.stream()
-                                .map(team -> {
-                                    team.getTeam().setLeagueId(leagueId);
-                                    return team;
-                                })
-                                .toList()
-                ));
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse schedule data", e);
-        }
-
-        return result;
-    }
-
     public List<Match> getMatchesByDate(LocalDateTime startOfDay, LocalDateTime endOfDay) {
         return matchRepository.findMatchesByDate(startOfDay, endOfDay);
     }
@@ -256,58 +75,44 @@ public class MatchService {
 
     public List<MatchDto> getMatchesByLeagueIdAndDate(String leagueId, LocalDate startDate, LocalDate endDate) {
         logger.info("==================== [경기 일정 조회 시작] ====================");
+        StopWatch sw = new StopWatch(); sw.start();
 
-        StopWatch sw = new StopWatch();
-        sw.start();
+        LocalDateTime startOfDay = startDate.atStartOfDay();
+        LocalDateTime endOfDay = endDate.plusDays(1).atStartOfDay().minusNanos(1);
 
-        List<MatchDto> result = new ArrayList<>();
-
-        String redisKey = String.join(":", "match", leagueId, startDate.toString(), endDate.toString());
-
-        List<MatchDto> cachedMatches = getMatchList(redisKey);
-
-        if (cachedMatches != null) {
-            logger.info(">>> Redis 캐시 Hit: {}", redisKey);
-            result.addAll(cachedMatches);
-        } else {
-            // 캐시 없을 경우 DB 조회 + 캐시 저장 로직
-            logger.info(">>> Redis 캐시 Miss. DB 조회 시작: {}", redisKey);
-            
-            LocalDateTime startOfDay = startDate.atStartOfDay();
-            LocalDateTime endOfDay;
-
-            if (startDate.equals(endDate)) {
-                // 하루만 조회할 경우: 해당 날짜의 끝까지
-                endOfDay = startDate.plusDays(1).atStartOfDay().minusNanos(1);
-            } else {
-                // 여러 날 조회할 경우: endDate의 끝까지 포함
-                endOfDay = endDate.plusDays(1).atStartOfDay().minusNanos(1);
-            }
-
-            List<Match> matches = matchRepository.findMatchByLeagueIdAndDate(leagueId, startOfDay, endOfDay);
-            result = matches.stream().map(matchMapper::entityToDto).toList();
-
-            // 캐시 저장
-            cacheMatchList(redisKey, result);
-        }
+        List<MatchDto> result = getMatchesWithCache(leagueId, startDate, endDate, () ->
+                matchRepository.findMatchByLeagueIdAndDate(leagueId, startOfDay, endOfDay)
+        );
 
         sw.stop();
         logger.info(">>> 소요 시간: {}ms", sw.getTotalTimeMillis());
         logger.info("==================== [경기 일정 조회 완료] ====================");
-        
         return result;
     }
 
-    // 캐싱 (연도별 리그 데이터 조회에서 사용 후 조회 소요 시간 1~2초 이상 -> 100ms 미만)
-    // key: "match:leagueId:startDate:endDate" 로 저장
-    public void cacheMatchList(String key, List<MatchDto> matches) {
-        matchRedisTemplate.opsForValue().set(key, matches, Duration.ofMinutes(10));
-        logger.info(">>> Cached matches for key: {}", key);
+    private List<MatchDto> getMatchesWithCache(
+            String leagueId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Supplier<List<Match>> dbFallback
+    ) {
+        String redisKey = String.join(":", "match", leagueId, startDate.toString(), endDate.toString());
+        List<MatchDto> cached = matchCacheService.getCachedMatchList(redisKey);
+
+        if (cached != null) {
+            logger.info(">>> Redis 캐시 Hit: {}", redisKey);
+            return cached;
+        }
+
+        logger.info(">>> Redis 캐시 Miss. DB 조회 시작: {}", redisKey);
+
+        List<Match> matches = dbFallback.get();
+        List<MatchDto> dtos = matches.stream().map(matchMapper::entityToDto).toList();
+        matchCacheService.cacheMatchList(redisKey, dtos);
+
+        return dtos;
     }
 
-    public List<MatchDto> getMatchList(String key) {
-        return matchRedisTemplate.opsForValue().get(key);
-    }
 
     public List<MatchDto> getMatchesByMatchIds(List<String> matchIds) {
         return matchRepository.findByMatchIdIn(matchIds)
@@ -316,8 +121,15 @@ public class MatchService {
                 .collect(Collectors.toList());
     }
 
+    // 리그id, 연도별 데이터 동기화 (블로킹 방식)
+    public void syncMatchesByExternalApi(List<String> leagueIds, String year) {
+        leagueIds.forEach(
+                leagueId -> syncMatchService.syncMatchesByLeagueIdAndYearExternalApi(leagueId, year)
+        );
+    }
 
-    // TODO 삭제 ----------------------------------------------------------------------------
+
+    // 250526 미사용. 참고용. ==================================================
 
     // 양방향 연관관계로 인한 순환참조 이슈 해결 방법 더 알아보기
     //  -> findMatchByLeagueIdAndDate 메서드 사용으로 변경
@@ -350,83 +162,5 @@ public class MatchService {
                 .toList();
     }*/
 
-    // 리그id, 연도별 데이터 동기화
-    /*public List<MatchDto> getMatchesByLeagueIdAndYearFromExternalApi(String leagueId, String year) {
-
-        List<MatchDto> allMatches = new ArrayList<>();
-        String nextPageToken = null;
-
-        do {
-            String finalToken = nextPageToken;
-
-            Mono<String> response = apiClient.fetchScheduleJsonByLeagueIdAndPageToken(leagueId, finalToken);
-
-            try {
-                JsonNode root = objectMapper.readTree(response.block());
-                JsonNode schedule = root.path("data").path("schedule");
-                JsonNode events = schedule.path("events");
-
-                List<MatchDto> pageMatches = parseMatchesFromEvents(events, leagueId, year);
-                allMatches.addAll(pageMatches);
-
-                // 중단 조건: 더 이상 해당 연도의 이벤트가 없음
-                boolean allBeforeTargetYear = StreamSupport.stream(events.spliterator(), false)
-                        .noneMatch(event -> event.path("startTime").asText().startsWith(year));
-                if (allBeforeTargetYear) break;
-
-                JsonNode pages = schedule.path("pages");
-                nextPageToken = pages.path("older").asText(null);
-
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to parse response", e);
-            }
-
-        } while (nextPageToken != null);
-
-        return allMatches;
-    }*/
-
-    /*public List<MatchDto> parseMatchesFromEvents(JsonNode events, String leagueId, String year) {
-        List<MatchDto> result = new ArrayList<>();
-
-        for (JsonNode event : events) {
-            String startTime = event.path("startTime").asText();
-            if (!startTime.startsWith(year)) continue;
-
-            List<MatchTeamDto> matchTeamDtos = StreamSupport.stream(
-                            event.path("match").path("teams").spliterator(), false)
-                    .map(team -> new MatchTeamDto(
-                            team.path("result").path("outcome").asText(),
-                            team.path("result").path("gameWins").asInt(),
-                            new TeamDto(team.path("code").asText(),
-                                    team.path("name").asText())
-                    ))
-                    .toList();
-
-            boolean completed = event.path("state").asText().equalsIgnoreCase("completed");
-            String winningTeamCode = completed
-                    ? matchTeamDtos.stream()
-                    .filter(team -> "win".equalsIgnoreCase(team.getOutcome()))
-                    .map(matchTeamDto -> matchTeamDto.getTeam().getCode())
-                    .findFirst().orElse(null)
-                    : null;
-
-            result.add(new MatchDto(
-                    event.path("match").path("id").asText(),
-                    startTime,
-                    event.path("state").asText(),
-                    event.path("strategy").path("type").asText(),
-                    winningTeamCode,
-                    matchTeamDtos.stream()
-                            .map(team -> {
-                                team.getTeam().setLeagueId(leagueId);
-                                return team;
-                            })
-                            .toList()
-            ));
-        }
-
-        return result;
-    }*/
 
 }

--- a/src/main/java/com/test/basic/lol/sync/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/sync/SyncMatchService.java
@@ -1,8 +1,11 @@
 package com.test.basic.lol.sync;
 
-import com.test.basic.lol.api.LolEsportsApiClient;
-import com.test.basic.lol.matches.Match;
 import com.test.basic.lol.api.dto.matches.MatchDetailResponse;
+import com.test.basic.lol.api.dto.matches.MatchScheduleResponse;
+import com.test.basic.lol.leagues.League;
+import com.test.basic.lol.leagues.LeagueRepository;
+import com.test.basic.lol.matches.Match;
+import com.test.basic.lol.matches.MatchApiService;
 import com.test.basic.lol.matches.MatchRepository;
 import com.test.basic.lol.matchteams.MatchTeam;
 import com.test.basic.lol.matchteams.MatchTeamRepository;
@@ -18,6 +21,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,11 +34,13 @@ import java.util.concurrent.TimeUnit;
 public class SyncMatchService {
     private static Logger logger = LoggerFactory.getLogger(SyncMatchService.class);
 
+    private final MatchApiService matchApiService;
+
+    private final LeagueRepository leagueRepository;
     private final MatchRepository matchRepository;
     private final TeamRepository teamRepository;
     private final MatchTeamRepository matchTeamRepository;
 
-    private final LolEsportsApiClient apiClient;
     private final RedissonClient redissonClient;
     private RLock lock;
 
@@ -66,7 +74,7 @@ public class SyncMatchService {
                 String matchId = match.getMatchId();
 
                 // matchid로 경기 상세 api 요청&응답 수신
-                Mono<MatchDetailResponse> monoResponse = apiClient.fetchMatchDetailFromApi(matchId);
+                Mono<MatchDetailResponse> monoResponse = matchApiService.fetchMatchDetailFromApi(matchId);
                 MatchDetailResponse response = monoResponse.block();    // 데이터 비교 위해 동기식으로 요청
 
                 if (response == null || response.getData() == null || response.getData().getEvent() == null) {
@@ -181,4 +189,184 @@ public class SyncMatchService {
             logger.warn(">>> 락 해제 시도 없음 (락 획득 실패 또는 타임아웃에 의한 자동 해제)");
         }
     }
+
+    // 파라미터로 전달된 YEAR 데이터까지만 갱신.
+    // EX) 2022를 전달한 경우, 금년 2025부터~2024,2023,2022 데이터 갱신
+    public void syncMatchesByLeagueIdAndYearExternalApi(String leagueId, String year) {
+        Optional<League> leagueOpt = leagueRepository.findByLeagueId(leagueId);
+        if (leagueOpt.isEmpty()) {
+            throw new RuntimeException("League not found with id: " + leagueId);
+        }
+
+        int targetYear = Integer.parseInt(year);
+        String nextPageToken = null;
+
+        do {
+            String finalToken = nextPageToken;
+
+            MatchScheduleResponse response = matchApiService.fetchScheduleByLeagueIdAndPageToken(leagueId, finalToken);
+
+            if (response == null || response.getData() == null || response.getData().getSchedule() == null) {
+                break;
+            }
+
+            List<MatchScheduleResponse.EventDto> events = response.getData()
+                    .getSchedule()
+                    .getEvents();
+
+            // 1️⃣ 페이지 내 모든 이벤트가 targetYear보다 이전이면 종료
+            boolean allBeforeTargetYear = events.stream()
+                    .filter(event -> event.getStartTime() != null)
+                    .map(event -> OffsetDateTime.parse(event.getStartTime())
+                            .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                            .toLocalDateTime()
+                            .getYear())
+                    .allMatch(eventYear -> eventYear < targetYear);
+
+            if (allBeforeTargetYear) break;
+
+            for (MatchScheduleResponse.EventDto event : events) {
+                if (event.getMatch() == null || event.getStartTime() == null) continue;
+
+                // 시간대 포함된 문자열 -> LocalDateTime 변환
+                // OffsetDateTime 자체에 시간대가 있음 → 서울 시간대로 맞춤 변환
+                LocalDateTime eventDateTime = OffsetDateTime.parse(event.getStartTime())
+                        .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                        .toLocalDateTime();
+
+                int eventYear = eventDateTime.getYear();
+
+                // 2️⃣ 연도가 타겟보다 작으면 무시 (스킵)
+                if (eventYear < targetYear) continue;
+
+                MatchScheduleResponse.MatchDto matchDto = event.getMatch();
+
+                // [1] Match 저장
+                Match match = matchRepository.findByMatchId(matchDto.getId()).orElseGet(Match::new);
+                match.setMatchId(matchDto.getId());
+                match.setLeague(leagueOpt.get());
+                match.setStartTime(eventDateTime);
+                match.setState(event.getState());
+                match.setBlockName(event.getBlockName());
+                match.setGameCount(matchDto.getStrategy().getCount());
+                match.setStrategy(matchDto.getStrategy().getType() + matchDto.getStrategy().getCount());
+
+                Match savedMatch = matchRepository.save(match);
+
+                // [2] MatchTeam 저장.
+                for (MatchScheduleResponse.TeamDto teamDto : matchDto.getTeams()) {
+                    Optional<Team> teamOpt;
+                    if (teamDto.getName().equalsIgnoreCase("TBD")) {    // TBD (To Be Determined)
+                        teamOpt = teamRepository.findByName(teamDto.getName());
+                    } else {
+                        teamOpt = teamRepository.findByCodeAndName(teamDto.getCode(), teamDto.getName());
+                    }
+
+                    if (teamOpt.isEmpty()) {
+                        throw new RuntimeException("Team not found with name: " + teamDto.getName());
+                    }
+
+                    Team team = teamOpt.get();
+                    MatchTeam matchTeam = matchTeamRepository
+                            .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
+                            .orElseGet(MatchTeam::new);
+
+                    matchTeam.setMatch(savedMatch);
+                    matchTeam.setTeam(team);
+
+                    if (teamDto.getResult() != null) {
+                        matchTeam.setOutcome(teamDto.getResult().getOutcome());
+                        matchTeam.setGameWins(teamDto.getResult().getGameWins());
+                    }
+
+                    matchTeamRepository.save(matchTeam);
+                }
+            }
+
+            nextPageToken = response.getData().getSchedule().getPages().getOlder();
+
+        } while (nextPageToken != null);
+    }
+
+    // 250526 미사용. 참고용. ==================================================
+
+    // 리그id, 연도별 데이터 동기화
+    /*public List<MatchDto> getMatchesByLeagueIdAndYearFromExternalApi(String leagueId, String year) {
+
+        List<MatchDto> allMatches = new ArrayList<>();
+        String nextPageToken = null;
+
+        do {
+            String finalToken = nextPageToken;
+
+            Mono<String> response = apiClient.fetchScheduleJsonByLeagueIdAndPageToken(leagueId, finalToken);
+
+            try {
+                JsonNode root = objectMapper.readTree(response.block());
+                JsonNode schedule = root.path("data").path("schedule");
+                JsonNode events = schedule.path("events");
+
+                List<MatchDto> pageMatches = parseMatchesFromEvents(events, leagueId, year);
+                allMatches.addAll(pageMatches);
+
+                // 중단 조건: 더 이상 해당 연도의 이벤트가 없음
+                boolean allBeforeTargetYear = StreamSupport.stream(events.spliterator(), false)
+                        .noneMatch(event -> event.path("startTime").asText().startsWith(year));
+                if (allBeforeTargetYear) break;
+
+                JsonNode pages = schedule.path("pages");
+                nextPageToken = pages.path("older").asText(null);
+
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse response", e);
+            }
+
+        } while (nextPageToken != null);
+
+        return allMatches;
+    }*/
+
+    /*public List<MatchDto> parseMatchesFromEvents(JsonNode events, String leagueId, String year) {
+        List<MatchDto> result = new ArrayList<>();
+
+        for (JsonNode event : events) {
+            String startTime = event.path("startTime").asText();
+            if (!startTime.startsWith(year)) continue;
+
+            List<MatchTeamDto> matchTeamDtos = StreamSupport.stream(
+                            event.path("match").path("teams").spliterator(), false)
+                    .map(team -> new MatchTeamDto(
+                            team.path("result").path("outcome").asText(),
+                            team.path("result").path("gameWins").asInt(),
+                            new TeamDto(team.path("code").asText(),
+                                    team.path("name").asText())
+                    ))
+                    .toList();
+
+            boolean completed = event.path("state").asText().equalsIgnoreCase("completed");
+            String winningTeamCode = completed
+                    ? matchTeamDtos.stream()
+                    .filter(team -> "win".equalsIgnoreCase(team.getOutcome()))
+                    .map(matchTeamDto -> matchTeamDto.getTeam().getCode())
+                    .findFirst().orElse(null)
+                    : null;
+
+            result.add(new MatchDto(
+                    event.path("match").path("id").asText(),
+                    startTime,
+                    event.path("state").asText(),
+                    event.path("strategy").path("type").asText(),
+                    winningTeamCode,
+                    matchTeamDtos.stream()
+                            .map(team -> {
+                                team.getTeam().setLeagueId(leagueId);
+                                return team;
+                            })
+                            .toList()
+            ));
+        }
+
+        return result;
+    }*/
+
 }


### PR DESCRIPTION
- 캐싱 로직을 MatchCacheService로 분리
- 외부 API 호출을 MatchApiService로 분리
- 데이터 동기화 메서드를 SyncMatchService로 이동