### PR TITLE
[feat] Spring Batch 기반 경기 일정 동기화 및 N+1 문제 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     // 채팅 기능 구현 (WebSocket + Redis Pub/Sub)
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
@@ -51,6 +52,7 @@ dependencies {
 
     // Entity <-> DTO 매핑 프레임워크
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    // MapStruct의 코드 생성기. 컴파일 시점에 @Mapper 인터페이스를 분석해서 자동으로 구현체 (Impl 클래스)를 생성
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     // WAR는 외부 Tomcat

--- a/src/main/java/com/test/basic/lol/batch/MatchAggregate.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchAggregate.java
@@ -1,0 +1,10 @@
+package com.test.basic.lol.batch;
+
+import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
+import com.test.basic.lol.domain.match.Match;
+
+import java.util.List;
+
+public record MatchAggregate(Match match, List<MatchScheduleResponse.TeamDto> teams) {
+    // constructor, getters, setters
+}

--- a/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
@@ -1,0 +1,111 @@
+package com.test.basic.lol.batch;
+
+
+import com.test.basic.lol.domain.league.LeagueRepository;
+import com.test.basic.lol.domain.match.MatchApiService;
+import com.test.basic.lol.domain.match.MatchRepository;
+import com.test.basic.lol.domain.matchteam.MatchTeamRepository;
+import com.test.basic.lol.domain.team.TeamRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableBatchProcessing
+public class MatchBatchConfig {
+
+    // TODO: Job, Step, Reader, Processor, Writer Bean 정의
+    //  - Job: syncMatchJob
+    //  - Step: syncMatchStep
+    //  - Reader: MatchItemReader (API 호출)
+    //  - Processor: MatchItemProcessor (EventDto -> MatchAggregate)
+    //  - Writer: MatchItemWriter (MatchAggregate -> DB 저장)
+
+    // 기본 제공 스키마 파일을 실행하여 Job 실행 상태, 이력 등을 저장할 메타 테이블 생성 (쿼리 경로 직접 지정)
+    @Profile({"dev", "prod"}) // 개발/운영만
+    @Bean
+    public DataSourceInitializer batchDataSourceInitializer(DataSource dataSource) {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScript(new ClassPathResource("org/springframework/batch/core/schema-postgresql.sql"));
+
+        // 에러 무시 설정 추가 (EX. 이미 관련 테이블 생성된 경우)
+        populator.setContinueOnError(true); // SQL 실행 중 에러가 나도 계속 실행
+        populator.setIgnoreFailedDrops(true); // DROP 구문 실패 무시 (선택적)
+
+        DataSourceInitializer initializer = new DataSourceInitializer();
+        initializer.setDataSource(dataSource);
+        initializer.setDatabasePopulator(populator);
+        return initializer;
+    }
+
+
+    @Bean
+    public Job syncMatchJob(JobRepository jobRepository, Step syncMatchStep) {
+        return new JobBuilder("syncMatchJob", jobRepository)
+                .start(syncMatchStep)
+                .build();
+    }
+
+    @Bean
+    public Step syncMatchStep(JobRepository jobRepository,
+                              PlatformTransactionManager transactionManager,
+                              MatchItemReader matchItemReader,
+                              MatchItemProcessor matchItemProcessor,
+                              MatchItemWriter matchItemWriter) {
+        return new StepBuilder("syncMatchStep", jobRepository)
+                .<MatchEventWithLeague, MatchAggregate>chunk(
+                        50,
+                        transactionManager
+                )
+                .reader(matchItemReader)
+                .processor(matchItemProcessor)
+                .writer(matchItemWriter)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public MatchItemReader matchItemReader(
+            @Value("#{jobParameters['leagueId']}") String leagueId,
+            @Value("#{jobParameters['targetYear']}") int targetYear,
+            MatchApiService matchApiService,
+            LeagueRepository leagueRepository) {
+
+        return new MatchItemReader(
+                leagueId,
+                targetYear,
+                matchApiService,
+                leagueRepository);
+    }
+
+    @Bean
+    public MatchItemProcessor matchItemProcessor() {
+        return new MatchItemProcessor();
+    }
+
+    @Bean
+    public MatchItemWriter matchItemWriter(
+            MatchRepository matchRepository,
+            TeamRepository teamRepository,
+            MatchTeamRepository matchTeamRepository
+    ) {
+        return new MatchItemWriter(
+                matchRepository,
+                teamRepository,
+                matchTeamRepository);
+    }
+}

--- a/src/main/java/com/test/basic/lol/batch/MatchEventWithLeague.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchEventWithLeague.java
@@ -1,0 +1,22 @@
+package com.test.basic.lol.batch;
+
+import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
+import com.test.basic.lol.domain.league.League;
+
+public class MatchEventWithLeague {
+    private final MatchScheduleResponse.EventDto event;
+    private final League league;
+
+    public MatchEventWithLeague(MatchScheduleResponse.EventDto event, League league) {
+        this.event = event;
+        this.league = league;
+    }
+
+    public MatchScheduleResponse.EventDto getEvent() {
+        return event;
+    }
+
+    public League getLeague() {
+        return league;
+    }
+}

--- a/src/main/java/com/test/basic/lol/batch/MatchItemProcessor.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemProcessor.java
@@ -1,0 +1,52 @@
+package com.test.basic.lol.batch;
+
+import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
+import com.test.basic.lol.domain.match.Match;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+
+/**
+ * EventDto → 저장할 Entity 생성
+ * Aggregate - 가공 완료된 도메인 묶음
+ */
+@RequiredArgsConstructor
+public class MatchItemProcessor implements ItemProcessor<MatchEventWithLeague, MatchAggregate> {
+
+    public MatchAggregate process(MatchEventWithLeague matchEventWithLeague) {
+        MatchScheduleResponse.EventDto event = matchEventWithLeague.getEvent();
+
+        if (event.getMatch() == null
+                || event.getStartTime() == null)
+            return null;
+
+        LocalDateTime eventTime = OffsetDateTime
+                .parse(event.getStartTime())
+                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
+
+        Match match = new Match();
+        match.setMatchId(event.getMatch().getId());
+        match.setLeague(matchEventWithLeague.getLeague());
+        match.setStartTime(eventTime);
+        match.setState(event.getState());
+        match.setBlockName(event.getBlockName());
+        match.setGameCount(event.getMatch().getStrategy().getCount());
+        match.setStrategy(
+                event.getMatch().getStrategy().getType() +
+                event.getMatch().getStrategy().getCount()
+        );
+
+        MatchAggregate mag = new MatchAggregate(
+                match,
+                event.getMatch().getTeams()
+        );
+
+        return mag;
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
@@ -1,0 +1,84 @@
+package com.test.basic.lol.batch;
+
+import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
+import com.test.basic.lol.domain.league.League;
+import com.test.basic.lol.domain.league.LeagueRepository;
+import com.test.basic.lol.domain.match.MatchApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemReader;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+
+@RequiredArgsConstructor
+public class MatchItemReader implements ItemReader<MatchEventWithLeague> {
+    private final String leagueId;
+    private final int targetYear;
+    private final MatchApiService matchApiService;
+    private final LeagueRepository leagueRepository;
+
+    private Queue<MatchScheduleResponse.EventDto> buffer = new LinkedList<>();
+    private String nextPageToken = null;
+    private boolean finished = false;
+
+    private final League league;
+
+
+    public MatchItemReader(String leagueId, int targetYear,
+                           MatchApiService matchApiService,
+                           LeagueRepository leagueRepository) {
+        this.leagueId = leagueId;
+        this.targetYear = targetYear;
+        this.matchApiService = matchApiService;
+        this.leagueRepository = leagueRepository;
+
+        this.league = leagueRepository.findByLeagueId(leagueId)
+                .orElseThrow(() -> new RuntimeException("League not found with id: " + leagueId));
+    }
+
+
+    // read 1번 -> EventDto 1개 반환
+    @Override
+    public MatchEventWithLeague read() {
+        if (finished) return null;
+
+        // 내부 버퍼링으로 fetch 최소화. (API 호출은 buffer가 비어 있을 때만)
+        while (buffer.isEmpty()) {
+            MatchScheduleResponse response = matchApiService.fetchScheduleByLeagueIdAndPageToken(leagueId, nextPageToken);
+            if (response == null || response.getData() == null || response.getData().getSchedule() == null) {
+//            logger.warn("[{}] 리그의 일정 정보가 비어 있습니다. nextToken: {}", leagueId, finalToken);
+                finished = true;
+                return null;
+            }
+
+            List<MatchScheduleResponse.EventDto> events = response.getData()
+                    .getSchedule()
+                    .getEvents()
+                    .stream()
+                    .filter(e -> e.getStartTime() != null)
+                    .filter(e -> OffsetDateTime.parse(e.getStartTime())
+                                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                                .toLocalDateTime().getYear() >= targetYear)
+                    .toList();
+
+            // 갱신 대상 이벤트가 없으면 reader 종료
+            if (events.isEmpty()) {
+                finished = true;
+                return null;
+            }
+
+            buffer.addAll(events);
+            nextPageToken = response.getData().getSchedule().getPages().getOlder();
+
+            if (nextPageToken == null && buffer.isEmpty()) {
+                finished = true;
+            }
+        }
+
+        return new MatchEventWithLeague(buffer.poll(), league);
+    }
+}

--- a/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
@@ -1,0 +1,92 @@
+package com.test.basic.lol.batch;
+
+import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
+import com.test.basic.lol.domain.match.Match;
+import com.test.basic.lol.domain.match.MatchRepository;
+import com.test.basic.lol.domain.matchteam.MatchTeam;
+import com.test.basic.lol.domain.matchteam.MatchTeamRepository;
+import com.test.basic.lol.domain.team.Team;
+import com.test.basic.lol.domain.team.TeamRepository;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public record MatchItemWriter(MatchRepository matchRepository, TeamRepository teamRepository,
+                              MatchTeamRepository matchTeamRepository) implements ItemWriter<MatchAggregate> {
+
+    // Spring Batch 5 이상. Chunk 객체 사용. (내부에 List를 포함한 래퍼)
+    // 데이터 + 배치 처리 관련 메타데이터
+    @Override
+    public void write(Chunk<? extends MatchAggregate> chunk) throws Exception {
+        List<MatchAggregate> items = (List<MatchAggregate>) chunk.getItems();
+
+        // 1. 모든 팀 코드 수집 (TBD 포함)
+        Set<String> teamCodes = new HashSet<>();
+        for (MatchAggregate mag : items) {
+            for (MatchScheduleResponse.TeamDto teamDto : mag.teams()) {
+                if (!teamDto.getName().equalsIgnoreCase("TBD")) {
+                    teamCodes.add(teamDto.getCode());
+                }
+            }
+        }
+
+        // 2. 한 번에 팀들 조회 (teamRepository에 findByCodeIn 메서드가 있어야 함)
+        List<Team> teams = teamRepository.findByCodeIn(teamCodes);
+        Map<String, Team> codeToTeamMap = teams.stream()
+                .collect(Collectors.toMap(Team::getCode, Function.identity()));
+
+        for (MatchAggregate mag : items) {
+            Match incoming = mag.match();
+
+            Match savedMatch = matchRepository.findByMatchId(incoming.getMatchId())
+                    .map(existing -> {
+                        existing.setStartTime(incoming.getStartTime());
+                        existing.setState(incoming.getState());
+                        existing.setBlockName(incoming.getBlockName());
+                        existing.setGameCount(incoming.getGameCount());
+                        existing.setStrategy(incoming.getStrategy());
+                        existing.setLeague(incoming.getLeague());
+                        return matchRepository.save(existing);
+                    })
+                    .orElseGet(() -> matchRepository.save(incoming));
+
+            for (MatchScheduleResponse.TeamDto teamDto : mag.teams()) {
+                Team team;
+
+                if (teamDto.getName().equalsIgnoreCase("TBD")) {
+                    // TBD 팀은 별도 조회 (기존 코드 재활용)
+                    Optional<Team> tbdTeamOpt = teamRepository.findByName(teamDto.getName());
+                    if (tbdTeamOpt.isEmpty()) {
+                        throw new RuntimeException("Team not found with name: " + teamDto.getName());
+                    }
+                    team = tbdTeamOpt.get();
+                } else {
+                    team = codeToTeamMap.get(teamDto.getCode());
+                    if (team == null) {
+                        throw new RuntimeException("Team not found with code: " + teamDto.getCode());
+                    }
+                }
+
+                MatchTeam matchTeam = matchTeamRepository
+                        .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
+                        .orElseGet(() -> {
+                            MatchTeam mt = new MatchTeam();
+                            mt.setMatch(savedMatch);
+                            mt.setTeam(team);
+                            return mt;
+                        });
+
+                if (teamDto.getResult() != null) {
+                    matchTeam.setOutcome(teamDto.getResult().getOutcome());
+                    matchTeam.setGameWins(teamDto.getResult().getGameWins());
+                }
+
+                matchTeamRepository.save(matchTeam);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/test/basic/lol/batch/sample/JobTriggerController.java
+++ b/src/main/java/com/test/basic/lol/batch/sample/JobTriggerController.java
@@ -1,0 +1,85 @@
+package com.test.basic.lol.batch.sample;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// TODO
+//  CommandLineRunner 또는 Scheduler로 실행하거나
+//  REST API 등을 통해 JobLauncher로 외부에서 실행
+//  사용 예) 처음 서버 올릴 때 API에서 데이터 싹 받아와서 DB에 넣는 작업을 자동으로 실행
+
+@RestController
+@RequestMapping("/lol/batch")
+@RequiredArgsConstructor
+@Tag(name = "[TEST] Batch Job Trigger API", description = "Batch Job Trigger API")
+public class JobTriggerController {
+
+    private final JobLauncher jobLauncher;  // Job을 실행하는 컴포넌트 (Job 실행 트리거)
+    private final Job exampleJob;
+    private final Job syncMatchJob;
+
+    private static final List<String> MAJOR_LEAGUE_IDS = List.of(
+            // LCK, LCK CL
+            "98767991310872058",
+            "98767991335774713",
+            // 국제 대회 (FIRST STAND, MSI, WORLDS)
+            "113464388705111224",
+            "98767991325878492",
+            "98767975604431411",
+            // LPL, LEC, ...
+            "98767991314006698",
+            "98767991302996019",
+            "98767991349978712",
+            "98767991299243165");
+
+/*
+    @GetMapping("/run-sample")
+    public String runJob() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(exampleJob, params);
+        return "Job 실행 완료!";
+    }
+*/
+
+
+    @GetMapping("/run-match-job")
+    public String runMatchJob(@RequestParam String year) {
+        for (String leagueId : MAJOR_LEAGUE_IDS) {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("leagueId", leagueId)
+                    .addLong("targetYear", Long.valueOf(year))
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+
+            try {
+                jobLauncher.run(syncMatchJob, params);
+            } catch (JobExecutionAlreadyRunningException | JobRestartException
+                     | JobInstanceAlreadyCompleteException | JobParametersInvalidException e) {
+                // 로그 출력
+//                log.error("Job 실행 실패 - leagueId: {}, year: {}", leagueId, year, e);
+                // 에러 메시지를 반환하거나, 필요에 따라 계속 진행할지 결정
+                return "Job 실행 실패: " + e.getMessage();
+            }
+        }
+
+        return "Match Job 실행 완료";
+    }
+}
+

--- a/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
@@ -138,7 +138,7 @@ public class SyncMatchService {
 
                     if (teamDto.getResult() != null) {
                         int newGameWins = teamDto.getResult().getGameWins();
-                        if (matchTeam.getGameWins() != newGameWins) {
+                        if (matchTeam.getGameWins() == null || matchTeam.getGameWins() != newGameWins) {
                             matchTeam.setGameWins(newGameWins);
                             teamUpdated = true;
                         }

--- a/src/main/java/com/test/basic/lol/domain/matchteam/MatchTeam.java
+++ b/src/main/java/com/test/basic/lol/domain/matchteam/MatchTeam.java
@@ -24,6 +24,7 @@ public class MatchTeam {
     @Column(length = 20)
     private String outcome;
 
+    // null일 수 있어서 Integer 사용. int는 null 저장 불가능
     private Integer gameWins;
 
 }

--- a/src/main/java/com/test/basic/lol/domain/team/Team.java
+++ b/src/main/java/com/test/basic/lol/domain/team/Team.java
@@ -5,13 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.test.basic.lol.domain.league.League;
 import com.test.basic.lol.domain.matchteam.MatchTeam;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Table(name = "teams", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"team_id"})
 })
@@ -42,7 +44,7 @@ public class Team {
     @JoinColumn(name = "league_id", referencedColumnName = "league_id", nullable = false)
     private League league;
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
     private List<MatchTeam> matchTeams;
 
     public Team(String teamId, String code, String name, String slug, String image, League league) {

--- a/src/main/java/com/test/basic/lol/domain/team/TeamRepository.java
+++ b/src/main/java/com/test/basic/lol/domain/team/TeamRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
@@ -43,6 +44,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findBySlugIn(List<String> slugs);
     List<Team> findByLeague_LeagueIdAndSlugIn(String leagueId, List<String> slugs);
     List<Team> findBySlugContaining(String slug);
+
+    List<Team> findByCodeIn(Set<String> teamCodes);
     //
 //    findByTeamName(String name)
 // WHERE team_name = ?

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -17,6 +17,11 @@ spring.sql.init.data-locations=classpath:/db/postgres/data.sql
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
+# Spring Batch 설정
+## 운영에서 DB 자동 생성 X. 커스텀 DataSourceInitializer 사용
+spring.batch.jdbc.initialize-schema=never
+spring.batch.job.enabled=false
+
 # Swagger UI 설정
 # API 문서 (JSON 형태) 활성화
 springdoc.api-docs.enabled=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -32,3 +32,10 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.h2.console.enabled=true
 ## H2 Console에 접근할 수 있는 URL 설정 (예: http://localhost:8080/h2-console)
 spring.h2.console.path=/h2-console
+
+
+# Spring Batch 설정
+## spring-batch-core-*.jar 안에 있는 DDL 스크립트를 DB에 실행. 내장 DB(H2 등)일 때만 자동 생성
+spring.batch.jdbc.initialize-schema=embedded
+## 스프링 컨텍스트에 등록된 첫 번째 Job 자동 실행x
+spring.batch.job.enabled=false


### PR DESCRIPTION
- 경기 일정 동기화에 Spring Batch 적용
    > Job, Step Bean 등록 및 커스텀 Reader, Processor, Writer 빈 생성
    > 배치 메타테이블 초기화 설정 추가 (dev, prod 프로파일)
    > 잡 실행 테스트용 트리거 컨트롤러 추가
- 연관관계 문제 방지
    > 엔티티의 @Data 어노테이션을 @Getter & @Setter로 변경 (toString 자동 생성 방지)
    > 팀 코드에 해당하는 팀 목록을 한 번에 조회하도록 개선