### PR TITLE
[feat] JVM 힙 및 Docker 컨테이너 메모리 제한 설정

### DIFF
--- a/.github/workflows/deploy-ssm-oidc.yml
+++ b/.github/workflows/deploy-ssm-oidc.yml
@@ -31,6 +31,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
+      # 컨테이너 --memory는 최소 -Xmx의 1.5배 이상 잡아야 안정적
       - name: "[4] Deploy to EC2 via SSM"
         run: |
           REPO_URL="ghcr.io/${{ github.repository }}"
@@ -40,7 +41,7 @@ jobs:
             \"sudo docker pull $REPO_URL:latest\",
             \"sudo docker stop basic-be || true\",
             \"sudo docker rm basic-be || true\",
-            \"sudo docker run -d --name basic-be -p 8080:8080 $REPO_URL:latest\",
+            \"sudo docker run --memory=256m --memory-swap=512m -d --name basic-be -p 8080:8080 $REPO_URL:latest\",
             \"sudo docker ps\"
           ]"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,6 @@ USER appuser
 COPY --from=build /app/build/libs/*.jar app.jar
 
 # 컨테이너 실행 시 JAR 파일 실행
-ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms64m", "-Xmx128m", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
 
 EXPOSE 8080


### PR DESCRIPTION
- EC2 인스턴스 메모리 부족으로 서버 다운되는 문제 대응
- JVM 힙 크기 제한(Xms/Xmx) 설정값 축소
- Docker 컨테이너에 메모리 및 스왑 메모리 제한 추가