### PR TITLE
[fix] 경기 일정 갱신 시 신규 생성한 MatchTeam 객체의 match 필드 누락 문제 해결

### DIFF
--- a/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
@@ -127,7 +127,12 @@ public class SyncMatchService {
 
                     MatchTeam matchTeam = matchTeamRepository
                             .findByMatch_MatchIdAndTeam_TeamId(match.getMatchId(), team.getTeamId())
-                            .orElseGet(MatchTeam::new);
+                            .orElseGet(() -> {
+                                // 여기서 새로 생성된 MatchTeam은 match 필드 값이 null이기 떄문에 세팅 필요
+                                MatchTeam mt = new MatchTeam();
+                                mt.setMatch(match);
+                                return mt;
+                            });
 
                     boolean teamUpdated = false;
 


### PR DESCRIPTION
- Hibernate not-null 제약 위반 문제 해결
- 새로 생성한 객체인 경우 match 정보 저장