### PR TITLE
[feat] CORS 환경 대응을 위한 커스텀 CSRF 설정 및 Swagger 연동 개선

### DIFF
--- a/src/main/java/com/test/basic/auth/AuthController.java
+++ b/src/main/java/com/test/basic/auth/AuthController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -37,6 +38,12 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     private final UserService userService;
+
+    @Value("${cookie.secure}")
+    private boolean isSecure;
+
+    @Value("${cookie.same-site}")
+    private String sameSite;
 
     @Autowired
     public AuthController(JwtTokenProvider jwtTokenProvider, UserService userService) {
@@ -98,26 +105,35 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
+    /**
+     * 쿠키 삭제는 기존 쿠키와 name, path, domain, secure, sameSite 등이 완전히 일치해야 합니다.
+     * maxAge(0)만 바꿔서 보내야 브라우저가 기존 쿠키를 "덮어써서 삭제"
+     */
     @GetMapping("/logout")
     @SecurityRequirement(name = "BearerAuth")  // 🔥 Swagger에서 JWT 인증 필요
     @Operation(summary = "로그아웃", description = "로그아웃 API")
     public ResponseEntity logout(HttpServletResponse response) {
         // 세션 쿠키를 만료시켜서 삭제
-        Cookie cookie = new Cookie("access_token", null);
-        cookie.setHttpOnly(true);  // 자바스크립트에서 쿠키를 접근할 수 없도록 설정
-        cookie.setPath("/");  // 쿠키의 경로를 현재 웹사이트의 루트로 설정
-        cookie.setMaxAge(0);  // 쿠키 만료 시간 설정 (0으로 설정하면 즉시 만료됨)
-        cookie.setSecure(true);  // HTTPS 연결에서만 쿠키가 전달됨
-//        cookie.setSecure(false);  // HTTP 연결에서 쿠키가 전달됨
-        response.addCookie(cookie);  // 쿠키를 응답에 추가하여 클라이언트에서 삭제되도록 함
+        ResponseCookie cookie = ResponseCookie.from("access_token", null)
+                .httpOnly(true)
+                .path("/")
+                .secure(isSecure)
+                .sameSite(sameSite)
+                .maxAge(0)  // 쿠키 만료 시간 0: 즉시 만료
+                .build();
 
-        Cookie refreshTokenCookie = new Cookie("refresh_token", null);
-        refreshTokenCookie.setHttpOnly(true);  // 자바스크립트에서 쿠키를 접근할 수 없도록 설정
-        refreshTokenCookie.setPath("/");  // 쿠키의 경로를 현재 웹사이트의 루트로 설정
-        refreshTokenCookie.setMaxAge(0);  // 쿠키 만료 시간 설정 (0으로 설정하면 즉시 만료됨)
-        refreshTokenCookie.setSecure(true);  // refreshToken 쿠키에 대해서도 동일
-//        refreshTokenCookie.setSecure(false);  // HTTP 연결에서 쿠키가 전달됨
-        response.addCookie(refreshTokenCookie);  // 쿠키를 응답에 추가하여 클라이언트에서 삭제되도록 함
+        response.addHeader("Set-Cookie", cookie.toString());  // 쿠키를 응답에 추가하여 클라이언트에서 삭제되도록 함
+
+        // refreshToken 쿠키에 대해서도 동일하게 설정
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", null)
+                .httpOnly(true)
+                .path("/")
+                .secure(isSecure)
+                .sameSite(sameSite)
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
         // 추가적으로 헤더에서 JWT 토큰 삭제 (필터에서 처리되는 부분)
         response.setHeader("Authorization", ""); // Authorization 헤더를 비워서 토큰 삭제

--- a/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
+++ b/src/main/java/com/test/basic/auth/csrf/CsrfTokenController.java
@@ -18,6 +18,6 @@ public class CsrfTokenController {
         // CSRF 토큰을 응답 헤더에 포함하여 반환
         return ResponseEntity.ok()
                 .header("X-CSRF-TOKEN", csrfToken.getToken())
-                .build();
+                .body(csrfToken.getToken());
     }
 }

--- a/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
@@ -29,7 +29,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -43,14 +45,17 @@ import org.springframework.security.oauth2.server.resource.web.access.BearerToke
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -67,6 +72,11 @@ public class SecurityConfig {
 	@Value("${jwt.private.key}")
 	RSAPrivateKey priv;
 
+	@Value("${cookie.secure}")
+	boolean isSecure;
+	@Value("${cookie.same-site}")
+	String sameSite;
+
 	/**
 	 * authorizeRequests().permitAll()은 특정 URL 경로에 대해 인증 없이 접근할 수 있도록 설정
 	 * formLogin().permitAll()은 로그인 폼을 모든 사용자가 접근할 수 있도록 설정
@@ -75,16 +85,34 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		// @formatter:off
 		http
-				// CSRF(Cross-Site Request Forgery) 공격은 사용자가 의도하지 않은 요청을 다른 사용자나 시스템에 보내는 공격
-				// jwt는 stateless 하기 때문에 session 쿠키 등을 통해 인증된 정보로 다른 사이트에 접근하는 공격인 csrf에 대한 방어 불필요
-				// 	But!!! 생성된 jwt 토큰을 session 쿠키에 저장해 사용하려면 방어 설정 필요!!
-//				.csrf((csrf) -> csrf.disable()) // security는 기본적으로 csrf(보안 공격) 공격에 대한 방어 세팅이 있으며, disable로 해제 가능
 				.authorizeHttpRequests((authorize) -> authorize
 						.requestMatchers("/", "/favicon.ico").permitAll()
-						.requestMatchers( "/css/**", "/js/**", "/images/**", "/html/**").permitAll()	// 정적 리소스 허용
-						.requestMatchers("/api/swagger-ui/**", "/api/v3/api-docs/**").permitAll()  // Swagger 허용
-						.requestMatchers("/auth/login", "/auth/signup").permitAll()  // 로그인, 회원가입 허용
-						.requestMatchers("/lol/**").permitAll()
+						// 정적 리소스
+						.requestMatchers( "/css/**", "/js/**", "/images/**", "/html/**").permitAll()
+						// Swagger
+						.requestMatchers("/api/swagger-ui/**", "/api/v3/api-docs/**").permitAll()
+						// 로그인, 회원가입
+						.requestMatchers("/auth/login", "/auth/signup").permitAll()
+						// lol
+						.requestMatchers(
+								"/lol/teams/sync",
+								"/lol/teams/sync-with-csrf",
+								"/lol/favorites/**",
+                                "/lol/matches/sync",
+								"/lol/batch/**"
+						).authenticated()
+						.requestMatchers(
+								"/lol/leagues",
+								"/lol/tournaments",
+								"/lol/teams/**",
+								"/lol/tournaments",
+								"/lol/matches", "/lol/matches/**",
+								"/lol/standings/**",
+								"/lol/matchhistory", "/lol/matchhistory/**"
+						).permitAll()
+						// post
+						.requestMatchers(HttpMethod.GET, "/posts").permitAll()
+						.requestMatchers(HttpMethod.POST, "/posts", "/posts/**").authenticated()
 						.requestMatchers("/mypage/manager").hasAuthority("SCOPE_ADMIN")  // 특정 권한 필요
 						.anyRequest().authenticated()  // 나머지 요청은 인증 필요
 				)
@@ -94,6 +122,9 @@ public class SecurityConfig {
 				.addFilterBefore(customJwtFilter(jwtTokenProvider()), UsernamePasswordAuthenticationFilter.class)
 //				.addFilterBefore(new CustomCsrfFilter(csrfRequireMatcher()), CustomJwtFilter.class) // CSRF 필터
 
+				// CORS 설정
+				.cors(Customizer.withDefaults()) // corsConfigurationSource() 자동 연결
+				
 				// 특정 요청에서 CSRF 해제
 				.csrf((csrf) -> csrf
 						.ignoringRequestMatchers(
@@ -103,10 +134,15 @@ public class SecurityConfig {
 							// 경기 전적 조회
 							new AntPathRequestMatcher("/lol/matchhistory")
 						)
-						.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // httpOnly: false (JS에서 읽을 수 있도록)
+						.csrfTokenRepository(customCsrfTokenRepository())
 						.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())	// 토큰 해석기 지정(spring security 6~)
 						.requireCsrfProtectionMatcher(csrfRequireMatcher())
 				)
+				// CSRF(Cross-Site Request Forgery) 공격은 사용자가 의도하지 않은 요청을 다른 사용자나 시스템에 보내는 공격
+				// jwt는 stateless 하기 때문에 session 쿠키 등을 통해 인증된 정보로 다른 사이트에 접근하는 공격인 csrf에 대한 방어 불필요
+				// 	But!!! 생성된 jwt 토큰을 session 쿠키에 저장해 사용하려면 방어 설정 필요!!
+//				.csrf((csrf) -> csrf.disable()) // security는 기본적으로 csrf(보안 공격) 공격에 대한 방어 세팅이 있으며, disable로 해제 가능
+
 				// Basic Authentication 인증 설정
 //				.httpBasic(Customizer.withDefaults())	// Basic Authentication 활성화
 				// basic 인증 실패 시 뜨는 id/pw 재인증 팝업 방지를 위해 커스텀 엔트리 포인트 설정
@@ -143,25 +179,6 @@ public class SecurityConfig {
 		// @formatter:on
 		return http.build();
 	}
-
-	// 애플리케이션 종료 시 사라짐. 테스트용 사용자 정보
-	/*@Bean
-	UserDetailsService users() {
-		// @formatter:off
-		UserDetails admin = User.withUsername("admin")
-				.password("{noop}admin") //{noop} 암호화 없이 저장
-				.authorities("ADMIN")
-				.build();
-
-		UserDetails user = User.builder()
-				.username("user")
-				.password("{noop}password")
-				.authorities("USER")
-				.build();	// SCOPE_ 접두사 자동 추가
-
-		// @formatter:on
-		return new InMemoryUserDetailsManager(admin, user);
-	}*/
 
 	@Bean
 	public CustomJwtFilter customJwtFilter(JwtTokenProvider jwtTokenProvider) {
@@ -200,10 +217,94 @@ public class SecurityConfig {
 	}
 
 
-	//. Spring Boot에서 CORS를 사용하고 있다면, 쿠키를 보내기 위해 Access-Control-Allow-Credentials: true를 설정해야 해.
+	// Spring Security 필터에서 CORS 처리 (필터체인 레벨에서 동작)
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowedOrigins(List.of(
+				"http://localhost:3000",
+				"https://localhost:3000",
+				"http://localhost:8080",
+				"https://localhost:8080",
+				"http://ec2-54-180-118-74.ap-northeast-2.compute.amazonaws.com",
+				"https://ec2-54-180-118-74.ap-northeast-2.compute.amazonaws.com"));  // 도메인 리스트
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+		config.setAllowedHeaders(List.of("Content-Type", "Authorization", "X-XSRF-TOKEN", "X-From-Swagger"));
+		config.setExposedHeaders(List.of("X-XSRF-TOKEN"));
+		config.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
+
+	@Bean
+	public CsrfTokenRepository customCsrfTokenRepository() {
+		CookieCsrfTokenRepository repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
+		repo.setCookieName("XSRF-TOKEN");
+
+		repo.setCookieCustomizer(builder -> builder
+				.path("/")
+				.httpOnly(false)
+				.secure(isSecure)
+				.sameSite(sameSite)
+//				.maxAge(Duration.ofHours(1))
+		);
+
+		return repo;
+	}
+
+	@Bean
+	public RequestMatcher csrfRequireMatcher() {
+		return new RequestMatcher() {
+			private static final Pattern ALLOWED_METHODS = Pattern.compile("^(GET|HEAD|TRACE|OPTIONS)$");
+
+			@Override
+			public boolean matches(HttpServletRequest request) {
+				if (ALLOWED_METHODS.matcher(request.getMethod()).matches()) {
+					return false;
+				}
+
+				// swagger 전용 헤더가 포함되어있다면 CORS 처리 X
+				if (request.getHeader("X-From-Swagger") != null
+						&& request.getHeader("X-From-Swagger").equalsIgnoreCase("skip")) {
+					return false;	// CSRF 보호를 건너뜀
+				}
+				return true;	// 나머지 요청은 CSRF 보호 유지
+			}
+		};
+	}
+
+
+
+//	TODO 삭제	===================================================================
+
+	// 애플리케이션 종료 시 사라짐. 테스트용 사용자 정보
+	/*@Bean
+	UserDetailsService users() {
+		// @formatter:off
+		UserDetails admin = User.withUsername("admin")
+				.password("{noop}admin") //{noop} 암호화 없이 저장
+				.authorities("ADMIN")
+				.build();
+
+		UserDetails user = User.builder()
+				.username("user")
+				.password("{noop}password")
+				.authorities("USER")
+				.build();	// SCOPE_ 접두사 자동 추가
+
+		// @formatter:on
+		return new InMemoryUserDetailsManager(admin, user);
+	}*/
+
+	
+	// Spring MVC 레벨 CORS 처리 (필터체인 이후 동작)
+	//	-> Spring Security 환경에서는 불충분한 설정 (이미 필터체인에서 cors 거부가 끝날 수 있기 때문)
+	// Spring Boot에서 CORS를 사용하고 있다면, 쿠키를 보내기 위해 Access-Control-Allow-Credentials: true를 설정해야 해.
 	// React 등 프론트엔드에서 백엔드 API를 호출할 때 CORS 오류를 방지
-	@Configuration
-	public class CorsConfig implements WebMvcConfigurer {
+	/*@Configuration
+	public static class CorsConfig implements WebMvcConfigurer {
 		public static final String ALLOWED_METHOD_NAMES = "GET,POST,PATCH,PUT,DELETE,OPTIONS";
 
 		@Override
@@ -221,27 +322,7 @@ public class SecurityConfig {
 					.allowedMethods(ALLOWED_METHOD_NAMES.split(","))	// 허용할 HTTP 메서드
 					.allowedHeaders("Content-Type", "Authorization", "X-XSRF-TOKEN", "X-From-Swagger") 	// 클라이언트가 보낼 수 있는 헤더
 					.exposedHeaders("X-XSRF-TOKEN")	// 클라이언트가 응답에서 읽을 수 있는 헤더
-					.allowCredentials(true);	// JWT 등 인증 정보(쿠키) 포함 허용 (credentials: 'include'가 포함된 요청 허용)
+					.allowCredentials(true);	// JWT, CSRF 등 인증 정보(쿠키) 포함 허용 (credentials: 'include'가 포함된 요청 허용)
 		}
-	}
-
-	@Bean
-	public RequestMatcher csrfRequireMatcher() {
-		return new RequestMatcher() {
-			private static final Pattern ALLOWED_METHODS = Pattern.compile("^(GET|HEAD|TRACE|OPTIONS)$");
-
-			@Override
-			public boolean matches(HttpServletRequest request) {
-				if (ALLOWED_METHODS.matcher(request.getMethod()).matches()) {
-					return false;
-				}
-
-				// swagger 전용 헤더가 포함되어있다면 CORS 처리 X
-				if (request.getHeader("X-From-Swagger") != null) {
-					return false;	// CSRF 보호를 건너뜀
-				}
-				return true;	// 나머지 요청은 CSRF 보호 유지
-			}
-		};
-	}
+	}*/
 }

--- a/src/main/java/com/test/basic/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/test/basic/common/config/swagger/SwaggerConfig.java
@@ -34,6 +34,14 @@ import java.util.List;
         in = SecuritySchemeIn.HEADER,
         paramName = "X-From-Swagger"
 )
+// 클라이언트와 서버가 동일한 도메인일 경우, swagger ui 내부 js 코드에서 x-xsrf-token 헤더에 자동으로 csrf 토큰 넣어서 보내줌
+// CORS 에선 검증 필요
+@SecurityScheme(
+        name = "CSRF",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.HEADER,
+        paramName = "X-XSRF-TOKEN"
+)
 public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {

--- a/src/main/java/com/test/basic/lol/domain/team/TeamController.java
+++ b/src/main/java/com/test/basic/lol/domain/team/TeamController.java
@@ -51,9 +51,11 @@ public class TeamController {
         }
     }
 
+
     @PostMapping("/sync")
     @PreAuthorize("hasAuthority('ADMIN')")
     @SecurityRequirement(name = "IgnoreCSRF")
+    @SecurityRequirement(name = "CSRF")
     @Operation(summary = "LOL 팀 정보 수동 동기화", description = "LOL 팀 정보 수동 동기화 API")
     public ResponseEntity<String> syncTeams() {
         logger.info("==================== 팀 정보 수동 동기화 작업 시작 ====================");
@@ -68,7 +70,5 @@ public class TeamController {
         logger.info("==================== 팀 정보 수동 동기화 작업 완료 ====================");
         return ResponseEntity.ok(result);
     }
-
-
 
 }

--- a/src/main/java/com/test/basic/lol/domain/team/favorite/FavoriteTeamController.java
+++ b/src/main/java/com/test/basic/lol/domain/team/favorite/FavoriteTeamController.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.domain.team.favorite;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ public class FavoriteTeamController {
 
     // 1. 즐겨찾기 등록
     @PostMapping("/{teamId}")
+    @SecurityRequirement(name = "CSRF")
     public ResponseEntity<String> addFavorite(@PathVariable String teamId,
                                               @AuthenticationPrincipal Jwt jwt) {
         Long userId = Long.valueOf(jwt.getClaim("sub"));
@@ -42,6 +44,7 @@ public class FavoriteTeamController {
 
     // 3. 즐겨찾기 삭제
     @DeleteMapping("/{teamId}")
+    @SecurityRequirement(name = "CSRF")
     public ResponseEntity<Void> removeFavorite(@PathVariable String teamId,
                                                @AuthenticationPrincipal Jwt jwt) {
         Long userId = Long.valueOf(jwt.getSubject());

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -62,7 +62,7 @@
 
     <!-- 개발: 콘솔 + 파일 동시 출력 -->
     <springProfile name="dev">
-        <root level="DEBUG">
+        <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="ERROR_FILE"/>


### PR DESCRIPTION
- CORS 환경에 맞게 CsrfTokenRepository 커스터마이징 (SameSite, Secure 등 속성 설정)
- WebMvcConfigurer -> CorsConfigurationSource 로 CORS 설정 위치 이전 (Security 필터 체인에서 처리되도록)
- 로그아웃으로 JWT 쿠키 삭제 시, 생성 시와 동일한 옵션으로 설정하여 정확한 제거 처리
- LOL 관련 API 중 갱신(쓰기) 요청은 인증 필수, 조회 요청은 permitAll로 구분
- Swagger UI 테스트용 CSRF 지원:
  - Swagger 테스트 편의를 위해 /csrf 응답 body에 토큰 포함
  - 즐겨찾기 추가/삭제 시 CSRF 검증 적용
  - 헤더에 우회 값 포함 시만 CSRF 검증 생략
  - CSRF 토큰 검증용 SecurityScheme 추가
  - LOL 팀 수동 동기화 API에 SecurityRequirement로 CSRF 토큰 or 우회 허용 설정
- 개발 환경에서 logback root 로그 레벨 INFO로 하향