### PR TITLE
[fix] Redisson 락 TTL 무한 증가로 인한 락 획득 실패 문제 해결

### DIFF
--- a/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
@@ -46,7 +46,8 @@ public class SyncMatchService {
             logger.info(">>> 락 획득 결과: {}, 대기 시간: {}ms", isLocked, (endTime - startTime));
 
             if (! isLocked) {
-                logger.warn(">>> 락 획득 실패. 이미 다른 동기화 작업이 진행 중.");
+                long ttl = lock.remainTimeToLive();
+                logger.warn(">>> 락 획득 실패. 현재 락 TTL: {}ms", ttl);
                 return;
             }
 
@@ -69,8 +70,12 @@ public class SyncMatchService {
     public void cleanup() {
         // 현재 스레드가 잡은 락인지 보장하기 위해 isHeldByCurrentThread() 꼭 확인
         if (lock != null && lock.isHeldByCurrentThread()) {
-            lock.unlock();
-            logger.info(">>> 락 해제 완료");
+            try {
+                lock.unlock();
+                logger.info(">>> 락 해제 완료");
+            } catch (IllegalMonitorStateException e) {
+                logger.warn(">>> 락 해제 중 예외 발생 (이미 해제되었거나 다른 쓰레드가 보유): {}", e.getMessage());
+            }
         } else {
             logger.warn(">>> 락 해제 시도 없음 (락 획득 실패 또는 타임아웃에 의한 자동 해제)");
         }
@@ -101,12 +106,14 @@ public class SyncMatchService {
     // EX) 2022를 전달한 경우, 금년 2025부터~2024,2023,2022 데이터 갱신
     @Transactional
     public void syncMatchesByLeagueIdsAndYear(List<String> leagueIds, String year) {
-        RLock lock = redissonClient.getLock(LOCK_KEY);
+        lock = redissonClient.getLock(LOCK_KEY);
         boolean isLocked = false;
 
         try {
             isLocked = lock.tryLock(1, TimeUnit.SECONDS);
             if (!isLocked) {
+                long ttl = lock.remainTimeToLive();
+                logger.warn(">>> 락 획득 실패. 현재 락 TTL: {}ms", ttl);
                 throw new RuntimeException("다른 동기화 작업이 실행 중입니다.");
             }
 
@@ -115,6 +122,7 @@ public class SyncMatchService {
             }
 
         } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("동기화 락 획득 중 인터럽트 발생", ie);
         } catch (Exception e) {
             logger.error("리그 동기화 실패: {}", e.getMessage(), e);


### PR DESCRIPTION
- 수동 경기 동기화 메서드에서 락 생성 방식을 지역 변수에서 클래스 인스턴스 필드로 변경
- 락 해제 누락 문제를 해결해 락 Watchdog에 의해 TTL이 계속 연장되는 현상 방지