### PR TITLE
[fix] TBD 팀 처리 로직 개선 및 경기 매칭팀 갱신 오류 수정

### DIFF
--- a/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
+++ b/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
@@ -63,7 +63,7 @@ public class JobTriggerController {
 
 
     @GetMapping("/run-match-job")
-    @Operation(summary = "경기 일정 갱신 배치", description = "EC2 프리티어는 싱글코어라 오히려 더 느림")
+    @Operation(summary = "경기 일정 갱신 배치", description = "경기 일정 갱신 배치 API (리그 파티셔닝 적용)")
     public String runMatchJob(@RequestParam String year) {
         StopWatch sw = new StopWatch();
         sw.start();

--- a/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
@@ -33,7 +33,6 @@ import javax.sql.DataSource;
     - Processor: MatchItemProcessor (EventDto -> MatchAggregate)
     - Writer: MatchItemWriter (MatchAggregate -> DB 저장)
 */
-// EC2 프리티어 사양이 너무 낮아서 돌리자마자 터져버림. 로컬 테스트만 가능..
 @Configuration
 @EnableBatchProcessing
 public class MatchBatchConfig {

--- a/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
@@ -64,15 +64,17 @@ public record MatchItemWriter(MatchRepository matchRepository, TeamRepository te
             List<MatchTeam> existingTeams = matchTeamRepository.findByMatch_MatchId(savedMatch.getMatchId());
 
             // 기존 데이터에 "TBD" 팀이 포함되어 있는지 확인
-            boolean existingHasTbd = existingTeams.stream()
-                    .anyMatch(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()));
+            long existingTbdCnt = existingTeams.stream()
+                    .filter(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()))
+                    .count();
 
             // 새로 가져온 팀 목록에 "TBD"가 없는지 확인
-            boolean incomingHasNoTbd = mag.teams().stream()
-                    .noneMatch(t -> "TBD".equalsIgnoreCase(t.getName()));
+            long incomingTbdCnt = mag.teams().stream()
+                    .filter(t -> "TBD".equalsIgnoreCase(t.getName()))
+                    .count();
 
-            // 기존에는 "TBD"가 있었고, 새 데이터에는 없다면 → 삭제
-            if (existingHasTbd && incomingHasNoTbd) {
+            // 기존 TBD 개수 != 새로운 팀 목록 TBD 개수 -> 기존 TBD 삭제
+            if (existingTbdCnt != incomingTbdCnt) {
                 matchTeamRepository.deleteByMatch_MatchIdAndTeam_Name(savedMatch.getMatchId(), "TBD");
             }
 
@@ -97,14 +99,21 @@ public record MatchItemWriter(MatchRepository matchRepository, TeamRepository te
                     }
                 }
 
-                MatchTeam matchTeam = matchTeamRepository
-                        .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
-                        .orElseGet(() -> {
-                            MatchTeam mt = new MatchTeam();
-                            mt.setMatch(savedMatch);
-                            mt.setTeam(team);
-                            return mt;
-                        });
+                MatchTeam matchTeam;
+                if (team.getName().equalsIgnoreCase("TBD")) {
+                    matchTeam = new MatchTeam();
+                    matchTeam.setMatch(savedMatch);
+                    matchTeam.setTeam(team);
+                } else {
+                    matchTeam = matchTeamRepository
+                            .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
+                            .orElseGet(() -> {
+                                MatchTeam mt = new MatchTeam();
+                                mt.setMatch(savedMatch);
+                                mt.setTeam(team);
+                                return mt;
+                            });
+                }
 
                 if (teamDto.getResult() != null) {
                     matchTeam.setOutcome(teamDto.getResult().getOutcome());

--- a/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
@@ -81,15 +81,17 @@ public class MatchSyncWorker {
         List<MatchTeam> existingTeams = matchTeamRepository.findByMatch_MatchId(match.getMatchId());
 
         // 기존 데이터에 "TBD" 팀이 포함되어 있는지 확인
-        boolean existingHasTbd = existingTeams.stream()
-                .anyMatch(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()));
+        long existingTbdCnt = existingTeams.stream()
+                .filter(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()))
+                .count();
 
         // 새로 가져온 팀 목록에 "TBD"가 없는지 확인
-        boolean incomingHasNoTbd = matchDetail.getTeams().stream()
-                .noneMatch(t -> "TBD".equalsIgnoreCase(t.getName()));
+        long incomingTbdCnt = matchDetail.getTeams().stream()
+                .filter(t -> "TBD".equalsIgnoreCase(t.getName()))
+                .count();
 
-        // 기존에는 "TBD"가 있었고, 새 데이터에는 없다면 → 삭제
-        if (existingHasTbd && incomingHasNoTbd) {
+        // 기존 TBD 개수 != 새로운 팀 목록 TBD 개수면 기존 TBD 삭제
+        if (existingTbdCnt != incomingTbdCnt) {
             matchTeamRepository.deleteByMatch_MatchIdAndTeam_Name(match.getMatchId(), "TBD");
         }
 
@@ -107,14 +109,20 @@ public class MatchSyncWorker {
 
             Team team = teamOpt.get();
 
-            MatchTeam matchTeam = matchTeamRepository
-                    .findByMatch_MatchIdAndTeam_TeamId(match.getMatchId(), team.getTeamId())
-                    .orElseGet(() -> {
-                        // 여기서 새로 생성된 MatchTeam은 match 필드 값이 null이기 떄문에 세팅 필요
-                        MatchTeam mt = new MatchTeam();
-                        mt.setMatch(match);
-                        return mt;
-                    });
+
+            MatchTeam matchTeam;
+            if (team.getName().equalsIgnoreCase("TBD")) {
+                matchTeam = new MatchTeam();
+                matchTeam.setMatch(match);
+            } else {
+                matchTeam = matchTeamRepository
+                        .findByMatch_MatchIdAndTeam_TeamId(match.getMatchId(), team.getTeamId())
+                        .orElseGet(() -> {
+                            MatchTeam mt = new MatchTeam();
+                            mt.setMatch(match);
+                            return mt;
+                        });
+            }
 
             boolean teamUpdated = false;
 
@@ -223,15 +231,17 @@ public class MatchSyncWorker {
                 List<MatchTeam> existingTeams = matchTeamRepository.findByMatch_MatchId(match.getMatchId());
 
                 // 기존 데이터에 "TBD" 팀이 포함되어 있는지 확인
-                boolean existingHasTbd = existingTeams.stream()
-                        .anyMatch(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()));
+                long existingTbdCnt = existingTeams.stream()
+                        .filter(mt -> "TBD".equalsIgnoreCase(mt.getTeam().getName()))
+                        .count();
 
                 // 새로 가져온 팀 목록에 "TBD"가 없는지 확인
-                boolean incomingHasNoTbd = matchDto.getTeams().stream()
-                        .noneMatch(t -> "TBD".equalsIgnoreCase(t.getName()));
+                long incomingTbdCnt = matchDto.getTeams().stream()
+                        .filter(t -> "TBD".equalsIgnoreCase(t.getName()))
+                        .count();
 
-                // 기존에는 "TBD"가 있었고, 새 데이터에는 없다면 → 삭제
-                if (existingHasTbd && incomingHasNoTbd) {
+                // 기존 TBD 개수 != 새로운 팀 목록 TBD 개수면 기존 TBD 삭제
+                if (existingTbdCnt != incomingTbdCnt) {
                     matchTeamRepository.deleteByMatch_MatchIdAndTeam_Name(match.getMatchId(), "TBD");
                 }
 
@@ -249,12 +259,22 @@ public class MatchSyncWorker {
                     }
 
                     Team team = teamOpt.get();
-                    MatchTeam matchTeam = matchTeamRepository
-                            .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
-                            .orElseGet(MatchTeam::new);
 
-                    matchTeam.setMatch(savedMatch);
-                    matchTeam.setTeam(team);
+                    MatchTeam matchTeam;
+                    if (team.getName().equalsIgnoreCase("TBD")) {
+                        matchTeam = new MatchTeam();
+                        matchTeam.setMatch(savedMatch);
+                        matchTeam.setTeam(team);
+                    } else {
+                        matchTeam = matchTeamRepository
+                                .findByMatch_MatchIdAndTeam_TeamId(savedMatch.getMatchId(), team.getTeamId())
+                                .orElseGet(() -> {
+                                    MatchTeam mt = new MatchTeam();
+                                    mt.setMatch(savedMatch);
+                                    mt.setTeam(team);
+                                    return mt;
+                                });
+                    }
 
                     if (teamDto.getResult() != null) {
                         matchTeam.setOutcome(teamDto.getResult().getOutcome());


### PR DESCRIPTION
- TBD 팀 개수 비교 방식으로 변경 (한 팀만 정해진 경우도 반영되도록)
- 경기 매칭팀이 모두 TBD인 경우 식별 불가능하므로 새 MatchTeam 객체 생성해 처리
- 경기일정 갱신 배치 API 주석 정리
- 불필요한 주석 삭제