### PR TITLE
[feat] 경기 일정 수동 갱신 시 전체 리그 대상으로 갱신하도록 변경

### DIFF
--- a/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
+++ b/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
@@ -1,5 +1,7 @@
 package com.test.basic.lol.batch;
 
+import com.test.basic.lol.domain.league.LeagueDto;
+import com.test.basic.lol.domain.league.LeagueService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +50,7 @@ public class JobTriggerController {
             "98767991314006698",
             "98767991302996019",
             "98767991349978712");
+    private final LeagueService leagueService;
 
 /*
     @GetMapping("/run-sample")
@@ -68,7 +71,13 @@ public class JobTriggerController {
         StopWatch sw = new StopWatch();
         sw.start();
 
-        for (String leagueId : MAJOR_LEAGUE_IDS) {
+        List<String> leagueIds = leagueService.getAllLeagues()
+                .stream()
+                .map(LeagueDto::getLeagueId)
+                .toList();
+
+//        for (String leagueId : MAJOR_LEAGUE_IDS) {
+        for (String leagueId : leagueIds) {
             JobParameters params = new JobParametersBuilder()
                     .addString("leagueId", leagueId)
                     .addLong("targetYear", Long.valueOf(year))

--- a/src/main/java/com/test/basic/lol/domain/match/MatchController.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchController.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.domain.match;
 
+import com.test.basic.lol.domain.league.LeagueService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -36,6 +37,7 @@ public class MatchController {
             "98767991314006698",
             "98767991302996019",
             "98767991349978712");
+    private final LeagueService leagueService;
 
 
     @GetMapping
@@ -71,7 +73,13 @@ public class MatchController {
         StopWatch sw = new StopWatch();
         sw.start();
 
-        syncMatchService.syncMatchesByLeagueIdsAndYear(MAJOR_LEAGUE_IDS, year);
+        List<String> leagueIds = leagueService.getAllLeagues()
+                .stream()
+                .map(leagueDto -> leagueDto.getLeagueId())
+                .toList();
+
+//        syncMatchService.syncMatchesByLeagueIdsAndYear(MAJOR_LEAGUE_IDS, year);
+        syncMatchService.syncMatchesByLeagueIdsAndYear(leagueIds, year);
 
         sw.stop();
         log.info(">>> 소요 시간: {}ms", sw.getTotalTimeMillis());

--- a/src/test/java/com/test/basic/lol/batch/JobTriggerControllerTest.java
+++ b/src/test/java/com/test/basic/lol/batch/JobTriggerControllerTest.java
@@ -45,7 +45,7 @@ public class JobTriggerControllerTest {
     private Job job;
 
     // TODO 테스트용 API 코드 분리
-    @Test
+    /*@Test
     @Disabled
     void testRunSampleJob_should_complete_successfully() throws Exception {
         MvcResult result = mockMvc.perform(get("/lol/batch/run-sample"))
@@ -56,5 +56,5 @@ public class JobTriggerControllerTest {
 
         assertThat(response).isNotNull();
         assertThat(response).isEqualTo("Job 실행 완료!");
-    }
+    }*/
 }


### PR DESCRIPTION
- 주요 8개 리그 -> 40개 리그 전체
- 배치 성능 테스트 목적