### PR TITLE
[feat] 경기 일정 배치 개선 및 동기화 결과 정보 출력

### DIFF
--- a/src/main/java/com/test/basic/lol/batch/LeaguePartitioner.java
+++ b/src/main/java/com/test/basic/lol/batch/LeaguePartitioner.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.batch;
 
+import com.test.basic.lol.domain.league.League;
 import com.test.basic.lol.domain.league.LeagueRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.partition.support.Partitioner;
@@ -34,11 +35,15 @@ public class LeaguePartitioner implements Partitioner {
     @Override
     public Map<String, ExecutionContext> partition(int gridSize) {
         Map<String, ExecutionContext> partitions = new HashMap<>();
-//        List<League> leagues = leagueRepository.findAll();
 
-        for (int i = 0; i < MAJOR_LEAGUE_IDS.size(); i++) {
+        List<String> leagueIds = leagueRepository.findAll()
+                .stream()
+                .map(League::getLeagueId)
+                .toList();
+
+        for (int i = 0; i < leagueIds.size(); i++) {
             ExecutionContext context = new ExecutionContext();
-            context.putString("leagueId", MAJOR_LEAGUE_IDS.get(i));
+            context.putString("leagueId", leagueIds.get(i));
             context.putInt("targetYear", Year.now().getValue());
             partitions.put("partition_" + i, context);
         }

--- a/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
@@ -64,6 +64,7 @@ public class MatchBatchConfig {
     public Job syncMatchJob(JobRepository jobRepository, Step syncMatchStep) {
         return new JobBuilder("syncMatchJob", jobRepository)
                 .start(syncMatchStep)
+                .listener(new SimpleJobListener())
                 .build();
     }
 
@@ -106,7 +107,7 @@ public class MatchBatchConfig {
                 .retry(Exception.class)     // 특정 예외만 재시도
                 .skip(DataIntegrityViolationException.class)   // 데이터 무결성 오류 스킵
                 .skip(ConstraintViolationException.class)     // 제약 조건 위반 스킵
-                .skipLimit(3)               // 최대 10개까지 건너뛰기
+                .skipLimit(3)               // 최대 3개까지 건너뛰기
                 .build();
     }
 

--- a/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
@@ -94,7 +94,9 @@ public class MatchItemReader implements ItemReader<MatchEventWithLeague> {
             logger.debug("[Thread: {}] 파티션 {} - MatchIds: {}",
                     Thread.currentThread().getName(),
                     leagueId,
-                    events.stream().map(event -> event.getMatch().getId()).toList()
+                    events.stream()
+                            .filter(event -> event.getMatch() != null)
+                            .map(event -> event.getMatch().getId()).toList()
             );
 
             // 갱신 대상 이벤트가 없으면 reader 종료

--- a/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
@@ -97,7 +97,8 @@ public record MatchItemWriter(MatchService matchService,
                 .stream()
                 .collect(Collectors.toMap(
                         Team::getName,
-                        Function.identity()
+                        Function.identity(),
+                        (existing, replacement) -> existing
                 ));
 
         log.debug("Deleting MatchTeams for {} matches", matchIds.size());

--- a/src/main/java/com/test/basic/lol/batch/SimpleJobListener.java
+++ b/src/main/java/com/test/basic/lol/batch/SimpleJobListener.java
@@ -1,0 +1,25 @@
+package com.test.basic.lol.batch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+
+@Slf4j
+public class SimpleJobListener implements JobExecutionListener {
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        // 처리된 총 개수만 출력
+        long totalCount = jobExecution.getStepExecutions()
+                .stream()
+                .mapToLong(StepExecution::getWriteCount)
+                .sum();
+
+        log.info("배치 완료 - 총 처리: {}건", totalCount);
+    }
+}

--- a/src/main/java/com/test/basic/lol/domain/league/LeagueController.java
+++ b/src/main/java/com/test/basic/lol/domain/league/LeagueController.java
@@ -39,7 +39,7 @@ public class LeagueController {
     @GetMapping
     public ResponseEntity<List<LeagueDto>> getAllLeagues() {
         return ResponseEntity.ok(leagueService.getAllLeagues().stream()
-                .filter(league -> MAJOR_LEAGUE_IDS.contains(league.getLeagueId()))
+//                .filter(league -> MAJOR_LEAGUE_IDS.contains(league.getLeagueId()))
                 .toList()
         );
     }

--- a/src/main/java/com/test/basic/lol/domain/match/MatchController.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchController.java
@@ -67,7 +67,7 @@ public class MatchController {
 
     @GetMapping("/sync")
     @Operation(summary = "리그별 경기일정 수동 동기화", description = "리그별 경기일정 수동 동기화 API")
-    public ResponseEntity syncAllMatchesByLeagueIdFromApi(@RequestParam(required = false) String year) {
+    public ResponseEntity syncAllMatchesByLeagueIdFromApi(@RequestParam String year) {
 
         // 소요 시간 측정
         StopWatch sw = new StopWatch();
@@ -84,7 +84,7 @@ public class MatchController {
         sw.stop();
         log.info(">>> 소요 시간: {}ms", sw.getTotalTimeMillis());
 
-        return ResponseEntity.ok("리그별 경기 일정 동기화 완료");
+        return ResponseEntity.ok("리그별 경기 일정 동기화 완료. 소요시간: " + sw.getTotalTimeMillis() + "ms");
     }
 
 

--- a/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
@@ -178,6 +178,7 @@ public class MatchSyncWorker {
         int targetYear = Integer.parseInt(year);
         String nextPageToken = null;
 
+        int count = 0;
         do {
             String finalToken = nextPageToken;
 
@@ -230,6 +231,7 @@ public class MatchSyncWorker {
                 match.setStrategy(matchDto.getStrategy().getType() + matchDto.getStrategy().getCount());
 
                 Match savedMatch = matchRepository.save(match);
+                count++;
 
 
                 // [2] MatchTeam 갱신
@@ -302,6 +304,8 @@ public class MatchSyncWorker {
             nextPageToken = response.getData().getSchedule().getPages().getOlder();
 
         } while (nextPageToken != null);
+
+        log.info("리그ID {} 데이터 갱신 완료 - {}건", leagueId, count);
     }
 
 


### PR DESCRIPTION
- 수동 경기 일정 동기화(싱글 스레드) 시 응답 바디에 소요 시간 포함
- 경기 정보 널 처리 로직 추가 (배치 중)
- 팀 정보 bulk 조회 시 중복 처리 파라미터 적용
- 배치 완료 후 처리 건수 출력용 JobListener 등록