### PR TITLE
[perf] EntityGraph로 Match 조회 성능 개선

### DIFF
--- a/src/main/java/com/test/basic/lol/domain/match/MatchRepository.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchRepository.java
@@ -1,8 +1,9 @@
 package com.test.basic.lol.domain.match;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -41,6 +42,8 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
             @Param("endOfDay") LocalDateTime endOfDay
     );
 
+    // 연관 관계 테이블 데이터를 JOIN해서 미리 조회 (EAGER LOADING)
+    @EntityGraph(attributePaths = {"matchTeams", "matchTeams.team"})
     @Query("""
         SELECT m FROM Match m
         WHERE m.league.leagueId = :leagueId

--- a/src/main/java/com/test/basic/lol/domain/team/Team.java
+++ b/src/main/java/com/test/basic/lol/domain/team/Team.java
@@ -44,6 +44,8 @@ public class Team {
     @JoinColumn(name = "league_id", referencedColumnName = "league_id", nullable = false)
     private League league;
 
+    // 기본값: LAZY. 연관 관계 테이블 데이터 필요할 때 조회
+    // N+1 문제 발생 가능. EX) MatchTeam.getTeam() <- MatchTeam마다 Team 조회
     @OneToMany(mappedBy = "team", fetch = FetchType.LAZY)
     private List<MatchTeam> matchTeams;
 


### PR DESCRIPTION
- N+1 문제로 인한 다중 쿼리를 단일 JOIN 쿼리로 최적화
- findMatchByLeagueIdAndDate에서 연관 엔티티 즉시 로딩 적용