### PR TITLE
[feat] 경기 일정 데이터 동기화 후 캐시 무효화 기능 추가

### DIFF
--- a/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
+++ b/src/main/java/com/test/basic/lol/batch/JobTriggerController.java
@@ -1,7 +1,6 @@
 package com.test.basic.lol.batch;
 
-import com.test.basic.lol.domain.league.LeagueDto;
-import com.test.basic.lol.domain.league.LeagueService;
+import com.test.basic.lol.domain.match.MatchCacheService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 // TODO
 //  CommandLineRunner 또는 Scheduler로 실행하거나
 //  REST API 등을 통해 JobLauncher로 외부에서 실행
@@ -35,9 +32,11 @@ import java.util.List;
 public class JobTriggerController {
 
     private final JobLauncher jobLauncher;  // Job을 실행하는 컴포넌트 (Job 실행 트리거)
-//    private final Job exampleJob;
     private final Job syncMatchJob;
+//    private final Job exampleJob;
 
+    private final MatchCacheService matchCacheService;
+    /*private final LeagueService leagueService;
     private static final List<String> MAJOR_LEAGUE_IDS = List.of(
             // LCK, LCK CL
             "98767991310872058",
@@ -49,8 +48,8 @@ public class JobTriggerController {
             // LPL, LEC, LJL
             "98767991314006698",
             "98767991302996019",
-            "98767991349978712");
-    private final LeagueService leagueService;
+            "98767991349978712");*/
+
 
 /*
     @GetMapping("/run-sample")
@@ -78,6 +77,9 @@ public class JobTriggerController {
                     .toJobParameters();
 
             jobLauncher.run(syncMatchJob, params);  // 한 번만 실행
+
+            // 배치 종료 후 경기 일정 캐시 무효화
+            matchCacheService.invalidateAllCaches();
         } catch (JobExecutionAlreadyRunningException | JobRestartException
                  | JobInstanceAlreadyCompleteException | JobParametersInvalidException e) {
             // 로그 출력
@@ -91,4 +93,3 @@ public class JobTriggerController {
         return "Match Job 실행 완료. 소요 시간: " + sw.getTotalTimeMillis() + "ms";
     }
 }
-

--- a/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerDev.java
+++ b/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerDev.java
@@ -1,6 +1,7 @@
 package com.test.basic.lol.batch.scheduler;
 
 import com.test.basic.lol.domain.match.Match;
+import com.test.basic.lol.domain.match.MatchCacheService;
 import com.test.basic.lol.domain.match.MatchService;
 import com.test.basic.lol.domain.match.SyncMatchService;
 import com.test.basic.lol.domain.team.SyncTeamService;
@@ -23,12 +24,14 @@ public class SyncLolEsportsSchedulerDev {
     private final SyncTeamService syncTeamService;
     private final SyncMatchService syncMatchService;
     private final MatchService matchService;
+    private final MatchCacheService matchCacheService;
 
     public SyncLolEsportsSchedulerDev(SyncTeamService syncTeamService,
-                                      SyncMatchService syncMatchService, MatchService matchService) {
+                                      SyncMatchService syncMatchService, MatchService matchService, MatchCacheService matchCacheService) {
         this.syncTeamService = syncTeamService;
         this.syncMatchService = syncMatchService;
         this.matchService = matchService;
+        this.matchCacheService = matchCacheService;
     }
 
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
@@ -65,6 +68,8 @@ public class SyncLolEsportsSchedulerDev {
 
         logger.info(">>> 동기화 대상 경기 수: {}", todayMatches.size());
         syncMatchService.syncTodaysMatchesFromLolEsportsApi(todayMatches);
+        // 경기 일정 동기화 후 캐시 무효화
+        matchCacheService.invalidateAllCaches();
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 완료] ====================");
     }
 

--- a/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerProd.java
+++ b/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerProd.java
@@ -1,6 +1,7 @@
 package com.test.basic.lol.batch.scheduler;
 
 import com.test.basic.lol.domain.match.Match;
+import com.test.basic.lol.domain.match.MatchCacheService;
 import com.test.basic.lol.domain.match.MatchService;
 import com.test.basic.lol.domain.match.SyncMatchService;
 import com.test.basic.lol.domain.team.SyncTeamService;
@@ -25,6 +26,7 @@ public class SyncLolEsportsSchedulerProd {
     private final SyncTeamService syncTeamService;
     private final MatchService matchService;
     private final SyncMatchService syncMatchService;
+    private final MatchCacheService matchCacheService;
 
     @Scheduled(cron = "0 0 3 ? * SUN", zone = "Asia/Seoul")
     public void syncTeamsProd() {
@@ -60,6 +62,8 @@ public class SyncLolEsportsSchedulerProd {
 
         logger.info(">>> 동기화 대상 경기 수: {}", todayMatches.size());
         syncMatchService.syncTodaysMatchesFromLolEsportsApi(todayMatches);
+        // 경기 일정 동기화 후 캐시 무효화
+        matchCacheService.invalidateAllCaches();
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 완료] ====================");
     }
 

--- a/src/main/java/com/test/basic/lol/domain/match/MatchCacheService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchCacheService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +53,24 @@ public class MatchCacheService {
         cachedMatches = matches;
         lastFetchedTime = Instant.now();
         logger.info(">>> 메모리 캐시 저장 완료");
+    }
+
+    /**
+     * 경기 일정 캐시 무효화
+     */
+    public void invalidateAllCaches() {
+        // 1. Redis 캐시 삭제
+        Set<String> keys = matchRedisTemplate.keys("match:*");
+        if (keys != null && !keys.isEmpty()) {
+            matchRedisTemplate.delete(keys);
+            logger.info(">>> Redis 경기 일정 캐시 삭제 완료: {} 개 키", keys.size());
+        }
+
+        // 2. 메모리 캐시 초기화
+        cachedMatches = null;
+        lastFetchedTime = null;
+
+        logger.info(">>> 경기 일정 캐시 무효화 완료");
     }
 
 }

--- a/src/main/java/com/test/basic/lol/domain/match/MatchController.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchController.java
@@ -23,9 +23,9 @@ import java.util.List;
 public class MatchController {
     private final MatchService matchService;
     private final SyncMatchService syncMatchService;
-//    private final SyncLolEsportsApiService syncLolEsportsApiService;
-
-    private static final List<String> MAJOR_LEAGUE_IDS = List.of(
+    private final MatchCacheService matchCacheService;
+    private final LeagueService leagueService;
+    /*private static final List<String> MAJOR_LEAGUE_IDS = List.of(
             // LCK, LCK CL
             "98767991310872058",
             "98767991335774713",
@@ -36,8 +36,7 @@ public class MatchController {
             // LPL, LEC, LJL
             "98767991314006698",
             "98767991302996019",
-            "98767991349978712");
-    private final LeagueService leagueService;
+            "98767991349978712");*/
 
 
     @GetMapping
@@ -80,6 +79,9 @@ public class MatchController {
 
 //        syncMatchService.syncMatchesByLeagueIdsAndYear(MAJOR_LEAGUE_IDS, year);
         syncMatchService.syncMatchesByLeagueIdsAndYear(leagueIds, year);
+
+        // 경기 일정 수동동기화 후 캐시 무효화
+        matchCacheService.invalidateAllCaches();
 
         sw.stop();
         log.info(">>> 소요 시간: {}ms", sw.getTotalTimeMillis());


### PR DESCRIPTION
- MatchCacheService에 invalidateAllCaches() 메서드 추가
- 배치, 수동 동기화, 스케줄러 완료 후 캐시 무효화 적용