### PR TITLE
[feat/fix] 배치 시스템 권한 체크 및 안정성 개선

### DIFF
--- a/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/test/basic/auth/security/config/SecurityConfig.java
@@ -33,6 +33,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -64,6 +65,7 @@ import java.util.regex.Pattern;
  * @author Josh Cummings
  */
 @Configuration
+@EnableMethodSecurity	// @PreAuthorize로 메서드 실행 전후에 권한 체크 활성화
 public class SecurityConfig {
 
 	@Value("${jwt.public.key}")

--- a/src/main/java/com/test/basic/lol/api/esports/LolEsportsApiClient.java
+++ b/src/main/java/com/test/basic/lol/api/esports/LolEsportsApiClient.java
@@ -1,31 +1,30 @@
 package com.test.basic.lol.api.esports;
 
-import com.test.basic.lol.domain.league.LeagueDto;
-import com.test.basic.lol.domain.league.LeagueResponse;
 import com.test.basic.lol.api.esports.dto.MatchDetailResponse;
 import com.test.basic.lol.api.esports.dto.MatchScheduleResponse;
 import com.test.basic.lol.api.esports.dto.StandingsResponse;
+import com.test.basic.lol.domain.league.LeagueDto;
+import com.test.basic.lol.domain.league.LeagueResponse;
 import com.test.basic.lol.domain.tournament.TournamentDto;
 import com.test.basic.lol.domain.tournament.TournamentResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 
-// TODO
-//  - response를 DTO로 받는 것 고려하기
-//  - LeagueId로 경기 일정 조회 (LCK CUP, LCK, MSI, EWC, WORLDS)
-//  - 연도별 경기 일정 배치 처리 + DB 저장(2022~)
 
 @Component
+@Slf4j
 public class LolEsportsApiClient {
 
     private final WebClient webClient;
-    private static final String HL = "ko-KR";
 
+    private static final String HL = "ko-KR";
 //    LCK 리그ID: 98767991310872058
 //    https://esports-api.lolesports.com/persisted/gw/getSchedule?hl=ko-KR&leagueId=98767991302996019
 
@@ -116,7 +115,8 @@ public class LolEsportsApiClient {
                     return uriBuilder.build();
                 })
                 .retrieve()
-                .bodyToMono(MatchScheduleResponse.class);
+                .bodyToMono(MatchScheduleResponse.class)
+                .timeout(Duration.ofSeconds(30));
     }
 
     /*public Mono<String> fetchScheduleJsonByLeagueIdAndPageToken(String leagueId, String finalToken) {

--- a/src/main/java/com/test/basic/lol/batch/LeaguePartitioner.java
+++ b/src/main/java/com/test/basic/lol/batch/LeaguePartitioner.java
@@ -3,8 +3,10 @@ package com.test.basic.lol.batch;
 import com.test.basic.lol.domain.league.League;
 import com.test.basic.lol.domain.league.LeagueRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.partition.support.Partitioner;
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Year;
@@ -14,11 +16,15 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@JobScope   // 기본 싱글톤 스코프에서는 JobParameters에 접근할 수 없어 명시적으로 설정
 public class LeaguePartitioner implements Partitioner {
 
     private final LeagueRepository leagueRepository;
 
-    private static final List<String> MAJOR_LEAGUE_IDS = List.of(
+    @Value("#{jobParameters['targetYear']}")
+    private String targetYear;
+
+    /*private static final List<String> MAJOR_LEAGUE_IDS = List.of(
             // LCK, LCK CL
             "98767991310872058",
             "98767991335774713",
@@ -29,7 +35,7 @@ public class LeaguePartitioner implements Partitioner {
             // LPL, LEC, LJL
             "98767991314006698",
             "98767991302996019",
-            "98767991349978712");
+            "98767991349978712");*/
 
 
     @Override
@@ -41,10 +47,14 @@ public class LeaguePartitioner implements Partitioner {
                 .map(League::getLeagueId)
                 .toList();
 
+        if (targetYear.isEmpty()) {
+            targetYear = String.valueOf(Year.now().getValue());
+        }
+
         for (int i = 0; i < leagueIds.size(); i++) {
             ExecutionContext context = new ExecutionContext();
             context.putString("leagueId", leagueIds.get(i));
-            context.putInt("targetYear", Year.now().getValue());
+            context.putString("targetYear", targetYear);
             partitions.put("partition_" + i, context);
         }
 

--- a/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchBatchConfig.java
@@ -130,7 +130,7 @@ public class MatchBatchConfig {
     @StepScope
     public MatchItemReader matchItemReader(
             @Value("#{stepExecutionContext['leagueId']}") String leagueId,
-            @Value("#{stepExecutionContext['targetYear']}") Integer targetYear,
+            @Value("#{stepExecutionContext['targetYear']}") String targetYear,
             MatchApiService matchApiService,
             LeagueService leagueService) {
 
@@ -138,17 +138,19 @@ public class MatchBatchConfig {
         
         return new MatchItemReader(
                 leagueId,
-                targetYear != null ? targetYear : Year.now().getValue(),
+                targetYear,
                 matchApiService,
                 leagueService);
     }
 
     @Bean
+    @StepScope
     public MatchItemProcessor matchItemProcessor() {
         return new MatchItemProcessor();
     }
 
     @Bean
+    @StepScope
     public MatchItemWriter matchItemWriter(
             MatchService matchService,
             TeamService teamService,

--- a/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemReader.java
@@ -16,7 +16,7 @@ public class MatchItemReader implements ItemReader<MatchEventWithLeague> {
     private static final Logger logger = LoggerFactory.getLogger(MatchItemReader.class);
 
     private final String leagueId;
-    private final int targetYear;
+    private final String targetYear;
     private final MatchApiService matchApiService;
     private final LeagueService leagueService;
 
@@ -28,7 +28,7 @@ public class MatchItemReader implements ItemReader<MatchEventWithLeague> {
     private League league;
 
 
-    public MatchItemReader(String leagueId, int targetYear,
+    public MatchItemReader(String leagueId, String targetYear,
                            MatchApiService matchApiService,
                            LeagueService leagueService) {
         this.leagueId = leagueId;
@@ -88,7 +88,7 @@ public class MatchItemReader implements ItemReader<MatchEventWithLeague> {
                     .filter(e -> e.getStartTime() != null)
                     .filter(e -> OffsetDateTime.parse(e.getStartTime())
                                 .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
-                                .toLocalDateTime().getYear() >= targetYear)
+                                .toLocalDateTime().getYear() >= Integer.parseInt(targetYear))
                     .toList();
 
             logger.debug("[Thread: {}] 파티션 {} - MatchIds: {}",

--- a/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
+++ b/src/main/java/com/test/basic/lol/batch/MatchItemWriter.java
@@ -6,6 +6,7 @@ import com.test.basic.lol.domain.matchteam.MatchTeam;
 import com.test.basic.lol.domain.matchteam.MatchTeamService;
 import com.test.basic.lol.domain.team.Team;
 import com.test.basic.lol.domain.team.TeamService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
@@ -15,9 +16,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
-public record MatchItemWriter(MatchService matchService,
-                              TeamService teamService,
-                              MatchTeamService matchTeamService) implements ItemWriter<MatchAggregate> {
+@RequiredArgsConstructor
+public class MatchItemWriter implements ItemWriter<MatchAggregate> {
+
+    private final MatchService matchService;
+    private final TeamService teamService;
+    private final MatchTeamService matchTeamService;
 
     // Spring Batch 5 이상. Chunk 객체 사용. (내부에 List를 포함한 래퍼)
     @Override

--- a/src/main/java/com/test/basic/lol/batch/controller/JobTriggerController.java
+++ b/src/main/java/com/test/basic/lol/batch/controller/JobTriggerController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,9 +25,9 @@ public class JobTriggerController {
     private final BatchJobService batchJobService;
 //    private final Job exampleJob;
 
-
     @GetMapping("/run-match-job")
     @Operation(summary = "경기 일정 갱신 배치", description = "경기 일정 갱신 배치 비동기 API (리그 파티셔닝 적용)")
+    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     public String runMatchJob(@RequestParam String year) {
         batchJobService.executeMatchSyncJob(year);
         return "경기 일정 갱신 배치 Job 시작. " + year + "년";

--- a/src/main/java/com/test/basic/lol/batch/service/BatchJobService.java
+++ b/src/main/java/com/test/basic/lol/batch/service/BatchJobService.java
@@ -35,7 +35,7 @@ public class BatchJobService {
 
     @Async("limitedTaskExecutor") // 명시적으로 TaskExecutor 지정
     public void executeMatchSyncJob(String year) {
-        String lockKey = "batch:sync-match:" + year;  // 연도별 락
+        String lockKey = "batch:sync-match";
         RLock matchSyncLock = redissonClient.getLock(lockKey);
 
         try {
@@ -60,7 +60,7 @@ public class BatchJobService {
             sw.start();
 
             JobParameters params = new JobParametersBuilder()
-                    .addLong("targetYear", Long.valueOf(year))
+                    .addString("targetYear", year)
                     .addLong("time", System.currentTimeMillis())
                     .addString("uuid", java.util.UUID.randomUUID().toString()) // 고유성 보장
                     .addString("thread", Thread.currentThread().getName()) // 디버깅용

--- a/src/main/java/com/test/basic/lol/domain/league/LeagueController.java
+++ b/src/main/java/com/test/basic/lol/domain/league/LeagueController.java
@@ -3,6 +3,7 @@ package com.test.basic.lol.domain.league;
 import com.test.basic.lol.api.esports.SyncLolEsportsApiService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,6 +46,7 @@ public class LeagueController {
     }
 
     @GetMapping("/sync")
+    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     public ResponseEntity<List<LeagueDto>> getAllLeaguesFromApi() {
         syncLolEsportsApiService.syncLeaguesFromLolEsportsApi();
         return ResponseEntity.ok(leagueService.getAllLeagues());

--- a/src/main/java/com/test/basic/lol/domain/match/MatchController.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.*;
 
@@ -66,6 +67,7 @@ public class MatchController {
     }
 
     @GetMapping("/sync")
+    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     @Operation(summary = "리그별 경기일정 수동 동기화", description = "리그별 경기일정 수동 동기화 API")
     public ResponseEntity syncAllMatchesByLeagueIdFromApi(@RequestParam String year) {
 
@@ -98,6 +100,7 @@ public class MatchController {
 
     // 해당 API는 단일 페이지 데이터만 동기화함
     /*@GetMapping("/sync")
+    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     public Mono<ResponseEntity<List<MatchDto>>> syncAllMatchesByLeagueIdFromApi() {
         // LCK, LCK CL, FIRST STAND, MSI, WORLDS
         List<String> leagueIds = List.of(

--- a/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchSyncWorker.java
@@ -44,7 +44,8 @@ public class MatchSyncWorker {
 
         if (response == null || response.getData() == null || response.getData().getEvent() == null) {
             log.warn("Data or event of Match [{}] is empty. {} ", matchId, response);
-            throw new RuntimeException("No match detail found for ID: " + matchId);
+//            throw new RuntimeException("No match detail found for ID: " + matchId);
+            return;
         }
 
         // 응답 결과와 db 데이터 비교

--- a/src/main/java/com/test/basic/lol/domain/team/TeamController.java
+++ b/src/main/java/com/test/basic/lol/domain/team/TeamController.java
@@ -53,7 +53,7 @@ public class TeamController {
 
 
     @PostMapping("/sync")
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     @SecurityRequirement(name = "03_CSRF")
     @SecurityRequirement(name = "04_IgnoreCSRF")
     @Operation(summary = "LOL 팀 정보 수동 동기화", description = "LOL 팀 정보 수동 동기화 API")

--- a/src/main/java/com/test/basic/lol/domain/tournament/TournamentController.java
+++ b/src/main/java/com/test/basic/lol/domain/tournament/TournamentController.java
@@ -4,6 +4,7 @@ import com.test.basic.lol.api.esports.SyncLolEsportsApiService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -40,6 +41,7 @@ public class TournamentController {
     }
 
     @GetMapping("/sync")
+//    @PreAuthorize("hasAuthority('SCOPE_ADMIN')")  // 권한 없이 갱신 가능여부 테스트용
     public ResponseEntity<List<TournamentDto>> getAllTournamentsByLeagueIdFromApi() {
         syncLolEsportsApiService.syncTournaments();
         return ResponseEntity.ok(tournamentService.getAllTournaments());


### PR DESCRIPTION
- @EnableMethodSecurity 활성화 및 리그/경기일정/팀 갱신 API에 SCOPE_ADMIN 권한 체크 추가
- 비동기 요청 시 스레드 풀 부족으로 step 중단되는 현상 해결 - 연도별 분산락을 공통 락 키로 통일하여 job 중복 실행 방지
- 리그 파티셔너에서 jobParameter 연도값 대신 Year.now().getValue()를 고정적으로 사용하던 오류 수정
- 경기일정 갱신 연도 파라미터 타입을 String으로 통일
- Processor, Writer도 @StepScope 적용 및 Writer를 record에서 일반 class로 변경하여 CGLIB 프록시 생성 오류 해결
- 일간 경기정보 갱신 시 빈 응답에 대한 예외 throw 비활성화, 로그 출력으로 변경