### PR TITLE
[feat] 리그/토너먼트/팀/순위표 정보 조회에 Spring Cache 적용

### DIFF
--- a/src/main/java/com/test/basic/common/config/RedisConfig.java
+++ b/src/main/java/com/test/basic/common/config/RedisConfig.java
@@ -1,13 +1,24 @@
 package com.test.basic.common.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.test.basic.chat.RedisMessageListener;
+import com.test.basic.lol.domain.league.LeagueDto;
 import com.test.basic.lol.domain.match.MatchDto;
+import com.test.basic.lol.domain.matchhistory.SummonerDto;
+import com.test.basic.lol.domain.standings.dto.StandingsDto;
+import com.test.basic.lol.domain.team.TeamDto;
+import com.test.basic.lol.domain.tournament.TournamentDto;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -15,11 +26,16 @@ import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Configuration
+@EnableCaching
 public class RedisConfig {
 
     private final StringRedisTemplate redisTemplate;    // 문자열(String) 데이터만 저장
@@ -29,6 +45,73 @@ public class RedisConfig {
         this.redisTemplate = redisTemplate;
         this.redisMessageListener = redisMessageListener;
     }
+
+    /**
+     * Spring Cache 전용 ObjectMapper 설정
+     * - DTO 전용으로 사용하여 순환 참조 방지
+     * - 타입 정보 저장 비활성화로 보안 및 호환성 개선
+     */
+    private ObjectMapper createCacheObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        // activateDefaultTyping 제거 - 보안 및 호환성 문제 해결
+        return mapper;
+    }
+
+    /**
+     * Spring Data Redis 캐시 매니저 (단일 캐시 매니저 사용)
+     * 각 캐시별 타입 지정된 직렬화 설정
+     */
+    @Bean
+    @Primary  // Redisson 캐시 매니저보다 우선 사용
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+
+        ObjectMapper objectMapper = createCacheObjectMapper();
+
+        // 순위표 캐시 30분
+        JavaType standingsListType = objectMapper.getTypeFactory().constructCollectionType(List.class, StandingsDto.class);
+        configs.put("standings", RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, standingsListType))));
+
+        // 리그, 토너먼트 캐시 3일
+        JavaType leagueListType = objectMapper.getTypeFactory().constructCollectionType(List.class, LeagueDto.class);
+        Jackson2JsonRedisSerializer<Object> leagueSerializer = new Jackson2JsonRedisSerializer<>(objectMapper, leagueListType);
+        configs.put("leagues", RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(3))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(leagueSerializer)));
+
+        JavaType tournamentListType = objectMapper.getTypeFactory().constructCollectionType(List.class, TournamentDto.class);
+        configs.put("tournaments", RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(3))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, tournamentListType))));
+
+        // 팀 캐시 7일
+        JavaType teamListType = objectMapper.getTypeFactory().constructCollectionType(List.class, TeamDto.class);
+        configs.put("teams", RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(7))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new Jackson2JsonRedisSerializer<>(objectMapper, teamListType))));
+
+        return RedisCacheManager.builder(connectionFactory)
+                // 기본 30분 TTL
+                .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+                        .entryTtl(Duration.ofMinutes(30))
+                        // Redis에 저장할 객체 직렬화 설정
+                        .serializeKeysWith(RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer()))   // 캐시 키를 문자열로 저장. 예: "teams::league1_[slug1,slug2]"
+                        .serializeValuesWith(RedisSerializationContext.SerializationPair
+                                .fromSerializer(new Jackson2JsonRedisSerializer<>(createCacheObjectMapper(), Object.class)))  // 캐시 값을 JSON으로 저장. 예: [{"teamId":"1","name":"팀A"}, {"teamId":"2","name":"팀B"}]
+                )
+                .withInitialCacheConfigurations(configs)
+                .build();
+    }
+
 
     // [1] 채팅용 ==================================================================
     // [1-1] 채팅 메시지 문자열 저장용 레디스 템플릿 등록

--- a/src/main/java/com/test/basic/lol/api/esports/SyncLolEsportsApiService.java
+++ b/src/main/java/com/test/basic/lol/api/esports/SyncLolEsportsApiService.java
@@ -10,6 +10,7 @@ import com.test.basic.lol.domain.tournament.Tournament;
 import com.test.basic.lol.domain.tournament.TournamentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -59,6 +60,7 @@ public class SyncLolEsportsApiService {
         }
     }
 
+    @CacheEvict(value = "tournaments", allEntries = true)
     public void syncTournaments() {
         List<League> savedLeagues = leagueRepository.findAll();
 

--- a/src/main/java/com/test/basic/lol/domain/league/LeagueService.java
+++ b/src/main/java/com/test/basic/lol/domain/league/LeagueService.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.domain.league;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public class LeagueService {
         this.leagueMapper = leagueMapper;
     }
 
+    @Cacheable("leagues")
     public List<LeagueDto> getAllLeagues() {
         return leagueRepository.findAll().stream()
                 .map(leagueMapper::entityToLeagueDto)

--- a/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/SyncMatchService.java
@@ -23,7 +23,7 @@ public class SyncMatchService {
 
     private final RedissonClient redissonClient;
     private RLock lock;
-    private String LOCK_KEY = "sync-matches-lock";
+    private final String LOCK_KEY = "sync-matches-lock";
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/src/main/java/com/test/basic/lol/domain/standings/StandingsService.java
+++ b/src/main/java/com/test/basic/lol/domain/standings/StandingsService.java
@@ -3,6 +3,7 @@ package com.test.basic.lol.domain.standings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.test.basic.lol.api.esports.LolEsportsApiClient;
 import com.test.basic.lol.api.esports.dto.StandingsResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -23,6 +24,7 @@ public class StandingsService {
         this.objectMapper = objectMapper;
     }
 
+    @Cacheable(value = "standings", key = "#tournamentId")
     public Mono<StandingsResponse.StandingsData> getStandingsByTournamentIdFromApi(String tournamentId) {
         return lolEsportsApiClient
                 .fetchStandings(tournamentId)

--- a/src/main/java/com/test/basic/lol/domain/team/SyncTeamService.java
+++ b/src/main/java/com/test/basic/lol/domain/team/SyncTeamService.java
@@ -10,6 +10,7 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
@@ -49,6 +50,7 @@ public class SyncTeamService {
     // RLock은 자동적으로 락 타임아웃을 처리. 
     // 락을 획득한 스레드가 락을 해제하지 않더라도, 일정 시간이 지나면 자동으로 락을 해제함
     @Transactional
+    @CacheEvict(value = "teams", allEntries = true)
     public String syncTeamsFromLolEsportsApi() {
         lock = redissonClient.getLock("sync-teams-lock");
         boolean isLocked = false;

--- a/src/main/java/com/test/basic/lol/domain/team/TeamService.java
+++ b/src/main/java/com/test/basic/lol/domain/team/TeamService.java
@@ -2,16 +2,14 @@ package com.test.basic.lol.domain.team;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.test.basic.lol.api.esports.LolEsportsApiClient;
-import com.test.basic.lol.domain.league.League;
 import com.test.basic.lol.domain.league.LeagueRepository;
 import com.test.basic.lol.domain.matchteam.MatchTeamService;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 // TODO 외부 API 데이터 바로 가져오는 로직 분리
@@ -40,29 +38,44 @@ public class TeamService {
         this.matchTeamService = matchTeamService;
     }
 
+    @Cacheable("teams")
     public List<Team> getAllTeamsFromDB() {
         return teamRepository.findAll();
     }
 
+    @Cacheable(value = "teams", key = "#leagueId + '_' + #slugs")
     public List<TeamDto> getTeamsFromDB(String leagueId, List<String> slugs) {
-        List<Team> teams;
+        List<Team> teams = getTeamsByCondition(leagueId, slugs);
+        return teams.stream().map(teamMapper::teamToTeamDto).toList();
+    }
 
-        // 둘 다 null 또는 비어있으면 전체 조회
-        if ((leagueId == null || leagueId.isBlank()) && (slugs == null || slugs.isEmpty())) {
-            teams = teamRepository.findTeamsWithMatches();
-        } else {
-            Optional<League> league = leagueRepository.findByLeagueId(leagueId);
-
-            if (league.get().getRegion().equals("국제 대회")) {
-                // 국제 대회 경기 일정이 있는 팀 목록 조회
-                List<String> teamIds = matchTeamService.findTeamIdsByLeagueId(leagueId);
-                teams = teamRepository.findByTeamIdIn(teamIds);
-            } else {
-                teams = teamRepository.findTeamsWithMatchesFiltered(leagueId, slugs);
-            }
+    public List<Team> getTeamsByCondition(String leagueId, List<String> slugs) {
+        // 전체 조회 (필터x)
+        if (isEmptyCondition(leagueId, slugs)) {
+            return teamRepository.findTeamsWithMatches();
         }
 
-        return teams.stream().map(teamMapper::teamToTeamDto).toList();
+        // 국제 대회 처리
+        if (isInternationalLeague(leagueId)) {
+            // 국제 대회 경기 일정이 있는 팀 목록 조회
+            List<String> teamIds = matchTeamService.findTeamIdsByLeagueId(leagueId);
+            return teamRepository.findByTeamIdIn(teamIds);
+        }
+
+        return teamRepository.findTeamsWithMatchesFiltered(leagueId, slugs);
+    }
+
+    private boolean isEmptyCondition(String leagueId, List<String> slugs) {
+        return (leagueId == null || leagueId.isBlank()) &&
+                (slugs == null || slugs.isEmpty());
+    }
+
+    private boolean isInternationalLeague(String leagueId) {
+        if (leagueId == null || leagueId.isBlank()) return false;
+
+        return leagueRepository.findByLeagueId(leagueId)
+                .map(league -> "국제 대회".equals(league.getRegion()))
+                .orElse(false);
     }
 
     public Team getTeamBySlugFromDB(String slug) {
@@ -99,16 +112,24 @@ public class TeamService {
         return teamRepository.findByNameIn(teamNames);
     }
 
-    public List<Team> getTeamsByCode(Set<String> duplicateCodes) {
+    @Cacheable(value = "teams", key = "#leagueId")
+    public List<TeamDto> getTeamsByLeagueId(String leagueId) {
+        return teamRepository.findByLeague_LeagueId(leagueId)
+                .stream()
+                .map(teamMapper::teamToTeamDto)
+                .toList();
+    }
+
+
+    // TODO 삭제 또는 리팩토링 =======================================================
+
+   /* public List<Team> getTeamsByCode(Set<String> duplicateCodes) {
         return teamRepository.findByCodeIn(duplicateCodes);
     }
 
     public Team getTeamByName(String teamName) {
         return teamRepository.findByName("TBD").orElse(null);
-    }
-
-
-    // TODO 삭제 또는 리팩토링 =======================================================
+    }*/
 
     // FIXME API 응답 데이터 DTO 따로 생성
     /*public TeamSyncDto getTeamBySlugFromExternalApi(String slug) {

--- a/src/main/java/com/test/basic/lol/domain/tournament/TournamentService.java
+++ b/src/main/java/com/test/basic/lol/domain/tournament/TournamentService.java
@@ -3,6 +3,7 @@ package com.test.basic.lol.domain.tournament;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.test.basic.lol.api.esports.LolEsportsApiClient;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -61,6 +62,7 @@ public class TournamentService {
 
     }*/
 
+    @Cacheable("tournaments")
     public List<TournamentDto> getAllTournaments() {
         return tournamentRepository.findAll()
                 .stream()
@@ -73,6 +75,7 @@ public class TournamentService {
                 .collect(Collectors.toList());
     }
 
+    @Cacheable(value = "tournaments", key = "#leagueId + '_' + #targetYear")
     public List<TournamentDto> getTournamentsByLeagueIdAndYear(String leagueId, String targetYear) {
         LocalDate today = LocalDate.now();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,13 @@ spring:
     # 환경변수로 오버라이드 가능
     default: ${SPRING_PROFILES_ACTIVE:prod}
 
+  # 캐시 설정
+  cache:
+    type: redis
+  autoconfigure:
+    exclude:
+      - org.redisson.spring.starter.RedissonAutoConfigurationV2  # 캐시 자동설정만 비활성화
+
   # 정적 파일 설정
   mvc:
     static-path-pattern: /**
@@ -40,6 +47,7 @@ logging:
     org.hibernate.engine.internal.StatefulPersistenceContext: WARN  # 1차 캐시 관련 디버깅 로그
     org.springframework.orm.jpa: ERROR
 
+
 jwt:
   private:
     key: classpath:jwt/app.key
@@ -62,6 +70,7 @@ cookie:
   secure: true
   same-site: None
 
+# Swagger OpenAPI
 springdoc:
   swagger-ui:
     csrf:


### PR DESCRIPTION
- @Cacheable을 통한 Redis 캐시 적용
- 리그: 3일, 토너먼트: 3일, 팀: 7일 TTL 설정
- Jackson 직렬화 이슈 해결 (타입별 Serializer 적용)