### PR TITLE
[feat] 경기일정 동기화 개선 및 새벽 배치 스케줄러 추가

### DIFF
--- a/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerDev.java
+++ b/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerDev.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.batch.scheduler;
 
+import com.test.basic.lol.batch.service.BatchJobService;
 import com.test.basic.lol.domain.match.Match;
 import com.test.basic.lol.domain.match.MatchCacheService;
 import com.test.basic.lol.domain.match.MatchService;
@@ -13,6 +14,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,24 +28,33 @@ public class SyncLolEsportsSchedulerDev {
     private final SyncMatchService syncMatchService;
     private final MatchService matchService;
     private final MatchCacheService matchCacheService;
+    private final BatchJobService batchJobService;
 
     public SyncLolEsportsSchedulerDev(SyncTeamService syncTeamService,
-                                      SyncMatchService syncMatchService, MatchService matchService, MatchCacheService matchCacheService) {
+                                      SyncMatchService syncMatchService, MatchService matchService, MatchCacheService matchCacheService, BatchJobService batchJobService) {
         this.syncTeamService = syncTeamService;
         this.syncMatchService = syncMatchService;
         this.matchService = matchService;
         this.matchCacheService = matchCacheService;
+        this.batchJobService = batchJobService;
     }
 
-    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 3 ? * SUN", zone = "Asia/Seoul")
     private void syncTeamsDev() {
         logger.info("==================== 팀 정보 자동 동기화 작업 시작 ====================");
         syncTeamService.syncTeamsFromLolEsportsApi();
         logger.info("==================== 팀 정보 자동 동기화 작업 완료 ====================");
     }
 
+//    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    @Scheduled(fixedDelay = 1000*60*10, initialDelay = 0)     // 즉시 시작 및 10분 간격으로 반복
+    private void syncAllMatchesDev() {
+        logger.info("==================== [전체 경기 일정 자동 동기화 배치 작업 시작] ====================");
+        batchJobService.executeMatchSyncJob(Year.now(ZoneId.of("Asia/Seoul")).toString());
+    }
 
-    @Scheduled(cron = "0 0/10 * * * *", zone = "Asia/Seoul")
+    // 서버 시작 후 5분 뒤 시작 및 10분 간격으로 반복
+    @Scheduled(fixedDelay = 1000*60*10, initialDelay = 1000*60*5) 
     private void syncTodaysMatchesFromApiDev() {
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 시작] ====================");
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerProd.java
+++ b/src/main/java/com/test/basic/lol/batch/scheduler/SyncLolEsportsSchedulerProd.java
@@ -1,5 +1,6 @@
 package com.test.basic.lol.batch.scheduler;
 
+import com.test.basic.lol.batch.service.BatchJobService;
 import com.test.basic.lol.domain.match.Match;
 import com.test.basic.lol.domain.match.MatchCacheService;
 import com.test.basic.lol.domain.match.MatchService;
@@ -14,6 +15,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +30,7 @@ public class SyncLolEsportsSchedulerProd {
     private final MatchService matchService;
     private final SyncMatchService syncMatchService;
     private final MatchCacheService matchCacheService;
+    private final BatchJobService batchJobService;
 
     @Scheduled(cron = "0 0 3 ? * SUN", zone = "Asia/Seoul")
     public void syncTeamsProd() {
@@ -35,8 +39,15 @@ public class SyncLolEsportsSchedulerProd {
         logger.info("==================== 팀 정보 자동 동기화 작업 완료 ====================");
     }
 
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    private void syncAllMatchesDev() {
+        logger.info("==================== [전체 경기 일정 자동 동기화 배치 작업 시작] ====================");
+        batchJobService.executeMatchSyncJob(Year.now(ZoneId.of("Asia/Seoul")).toString());
+    }
 
-    @Scheduled(cron = "0 0/10 * * * *", zone = "Asia/Seoul")
+
+    // 서버 시작 후 5분 뒤 시작 및 10분 간격으로 반복
+    @Scheduled(fixedDelay = 1000*60*10, initialDelay = 1000*60*5)
     private void syncTodaysMatchesFromApiDev() {
         logger.info("==================== [금일 경기 정보 자동 동기화 작업 시작] ====================");
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/test/basic/lol/domain/match/MatchController.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchController.java
@@ -66,7 +66,7 @@ public class MatchController {
         return ResponseEntity.ok(matches);
     }
 
-    @GetMapping("/sync")
+    @PostMapping("/sync")
     @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     @Operation(summary = "리그별 경기일정 수동 동기화", description = "리그별 경기일정 수동 동기화 API")
     public ResponseEntity syncAllMatchesByLeagueIdFromApi(@RequestParam String year) {

--- a/src/main/java/com/test/basic/lol/domain/match/MatchService.java
+++ b/src/main/java/com/test/basic/lol/domain/match/MatchService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
 
@@ -68,6 +69,7 @@ public class MatchService {
         return matchRepository.findMatchesByDate(startOfDay, endOfDay);
     }
 
+    @Cacheable(value = "firstMatchTime", key = "#startOfDay + '_' + #endOfDay")
     public Optional<LocalDateTime> getFirstMatchTimeOfDay(LocalDateTime startOfDay, LocalDateTime endOfDay) {
         return matchRepository.findFirstMatchTimeOfDay(startOfDay, endOfDay);
     }


### PR DESCRIPTION
- 수동 동기화 API POST로 변경 
- 금일 경기 일정 갱신 시 첫 경기시간 캐싱으로 성능 개선 
- 스케줄러 충돌 방지: cron->fixedDelay 변경, initialDelay로 실행시간 분리 
- 전체 일정 갱신 배치 추가 (매일 새벽4시)